### PR TITLE
Required-capability is now forced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
                                         javax.enterprise.inject.spi;version=!,
                                         *
                                     </Import-Package>
+                                    <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
                                 </instructions>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Required-capability is now forced due to osgi requirement in glassfish