### PR TITLE
Fixed @JsonbTypeDeserializer not being used when deserializing collec…

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractContainerDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractContainerDeserializer.java
@@ -14,6 +14,7 @@
 package org.eclipse.yasson.internal.serializer;
 
 import org.eclipse.yasson.internal.*;
+import org.eclipse.yasson.internal.model.ClassModel;
 import org.eclipse.yasson.internal.properties.MessageKeys;
 import org.eclipse.yasson.internal.properties.Messages;
 
@@ -120,7 +121,10 @@ public abstract class AbstractContainerDeserializer<T> extends AbstractItem<T> i
 
     protected JsonbDeserializer<?> newCollectionOrMapItem(Type valueType, JsonbContext ctx) {
         Type actualValueType = ReflectionUtils.resolveType(this, valueType);
-        return newUnmarshallerItemBuilder(ctx).withType(actualValueType).build();
+        ClassModel classModel = ctx.getMappingContext().getOrCreateClassModel(ReflectionUtils.getRawType(actualValueType));
+        return newUnmarshallerItemBuilder(ctx).withType(actualValueType)
+        		.withCustomization(classModel == null ? null : classModel.getCustomization())
+        		.build();
     }
 
     /**


### PR DESCRIPTION
The problem occurs when the annotation @JsonbTypeDeserializer is at class level, it's ignored when deserializing collection items.