### PR TITLE
Interface methods left out

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/ClassParser.java
+++ b/src/main/java/org/eclipse/yasson/internal/ClassParser.java
@@ -149,7 +149,8 @@ class ClassParser {
         Method[] declaredMethods = AccessController.doPrivileged((PrivilegedAction<Method[]>) clazz::getDeclaredMethods);
         for (Method method : declaredMethods) {
             String name = method.getName();
-            if (!isPropertyMethod(method)) {
+            //isBridge method filters out methods inherited from interfaces
+            if (!isPropertyMethod(method) || method.isBridge()) {
                 continue;
             }
             final String propertyName = toPropertyMethod(name);


### PR DESCRIPTION
Interface methods returned by clazz.getDeclaredMethods() are now left out from class processing.

Signed-off-by: David Kral <david.k.kral@oracle.com>