### PR TITLE
Fix for Yasson 172

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
@@ -29,6 +29,7 @@ import org.eclipse.yasson.internal.model.customization.Customization;
  * Deserializer for {@link Date} type.
  *
  * @author David Kral
+ * @author Dennis Kriechel
  */
 public class DateTypeDeserializer extends AbstractDateTimeDeserializer<Date> {
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
@@ -13,13 +13,15 @@
 
 package org.eclipse.yasson.internal.serializer;
 
-import org.eclipse.yasson.internal.model.customization.Customization;
-
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Locale;
+
+import org.eclipse.yasson.internal.model.customization.Customization;
 
 /**
  * Deserializer for {@link Date} type.
@@ -28,32 +30,61 @@ import java.util.Locale;
  */
 public class DateTypeDeserializer extends AbstractDateTimeDeserializer<Date> {
 
-    private static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME.withZone(UTC);
+	private static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
-    /**
-     * Creates an instance.
-     *
-     * @param customization Model customization.
-     */
-    public DateTypeDeserializer(Customization customization) {
-        super(Date.class, customization);
-    }
+	/**
+	 * Creates an instance.
+	 *
+	 * @param customization Model customization.
+	 */
+	public DateTypeDeserializer(Customization customization) {
+		super(Date.class, customization);
+	}
 
+	@Override
+	protected Date fromInstant(Instant instant) {
+		return new Date(instant.toEpochMilli());
+	}
 
-    @Override
-    protected Date fromInstant(Instant instant) {
-        return new Date(instant.toEpochMilli());
-    }
-
-    @Override
+	@Override
     protected Date parseDefault(String jsonValue, Locale locale) {
-        final TemporalAccessor parsed = DEFAULT_DATE_TIME_FORMATTER.withLocale(locale).parse(jsonValue);
+		TemporalAccessor parsed;
+		
+		if (hasOffset(jsonValue)) {
+			parsed = DEFAULT_DATE_TIME_FORMATTER.withLocale(locale).parse(jsonValue);
+		} else {
+			parsed = DEFAULT_DATE_TIME_FORMATTER.withZone(UTC).withLocale(locale).parse(jsonValue);
+		}
+    	
         return new Date(Instant.from(parsed).toEpochMilli());
     }
 
-    @Override
-    protected Date parseWithFormatter(String jsonValue, DateTimeFormatter formatter) {
-        final TemporalAccessor parsed = getZonedFormatter(formatter).parse(jsonValue);
-        return new Date(Instant.from(parsed).toEpochMilli());
-    }
+	@Override
+	protected Date parseWithFormatter(String jsonValue, DateTimeFormatter formatter) {
+		TemporalAccessor parsed;
+		
+		if (hasOffset(jsonValue)) {
+			parsed = formatter.parse(jsonValue);
+		} else {
+			parsed = formatter.withZone(UTC).parse(jsonValue);
+		}
+		
+		return new Date(Instant.from(parsed).toEpochMilli());
+	}
+
+	/**
+	 * Checks if a json date value contains an offset in terms of
+	 * java.time.OffsetDateTime
+	 * 
+	 * @param jsonValue Value from json
+	 * @return true if the value could be interpreted as an date with an offset
+	 */
+	private boolean hasOffset(String jsonValue) {
+		try {
+			OffsetDateTime.parse(jsonValue);
+			return true;
+		} catch (DateTimeParseException e1) {
+			return false;
+		}
+	}
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
@@ -63,21 +63,22 @@ public class DateTypeDeserializer extends AbstractDateTimeDeserializer<Date> {
 	}
 
 	/**
-	 * Parses the jsonValue as an Date.<br>
-	 * At first the Date is parsed with an Offset/ZoneId.<br>
-	 * If no Offset/ZoneId is present and the parsing fails, it will be parsed again with the fixed ZoneId that was passed as defaultZone.
+	 * Parses the jsonValue as a java.time.ZonedDateTime that can later be use to be converted into a java.util.Date.<br>
+	 * At first the Json-Date is parsed with an Offset/Zone.<br>
+	 * If no Offset/Zone is present and the parsing fails, it will be parsed again with the fixed Zone that was passed as defaultZone.
 	 * 
-	 * @param jsonValue Value from json
-	 * @param formatter DateFormat-Options
+	 * @param jsonValue String value from json
+	 * @param formatter DateTimeFormat options
 	 * @param defaultZone This Zone will be used if no other Zone was found in the jsonValue
-	 * @return Parsed Date
+	 * @return Parsed date on base of a java.time.ZonedDateTime
 	 */
 	private TemporalAccessor parseWithOrWithoutZone(String jsonValue, DateTimeFormatter formatter, ZoneId defaultZone) {
 		try {
+			// Try parsing with a Zone
 			return ZonedDateTime.parse(jsonValue, formatter);
 		} catch (DateTimeParseException e) {
-			e.printStackTrace();
-			// Exception occures possibly because no Offset/ZoneId was found
+			// Possibly exception occures because no Offset/ZoneId was found
+			// Therefore parse with defaultZone again
 			return ZonedDateTime.parse(jsonValue, formatter.withZone(defaultZone));
 		}
 	}

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -151,6 +151,7 @@ public class DatesTest {
 
     @Test
     public void testDateWithZoneOffset() throws ParseException {
+        // Test for Yasson-172
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
         final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
     	
@@ -162,6 +163,7 @@ public class DatesTest {
     
     @Test
     public void testDateWithZoneId() throws ParseException {
+        // Test for Yasson-172
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
         final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
     	

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -150,11 +150,22 @@ public class DatesTest {
     }
 
     @Test
-    public void testDateWithZone() throws ParseException {
+    public void testDateWithZoneOffset() throws ParseException {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
         final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
     	
     	String jsonDateWithZone = "{\"dateWithZone\":\"2018-11-02T00:00:00+01:00\"}";
+    	final DateWithZonePojo result = jsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
+    	
+    	assertEquals(parsedDate, result.dateWithZone);
+    }
+    
+    @Test
+    public void testDateWithZoneId() throws ParseException {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
+    	
+    	String jsonDateWithZone = "{\"dateWithZone\":\"2018-11-02T00:00:00+01:00[Europe/Berlin]\"}";
     	final DateWithZonePojo result = jsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
     	
     	assertEquals(parsedDate, result.dateWithZone);

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -16,6 +16,7 @@ import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.dates.model.CalendarPojo;
 import org.eclipse.yasson.defaultmapping.dates.model.ClassLevelDateAnnotation;
 import org.eclipse.yasson.defaultmapping.dates.model.DatePojo;
+import org.eclipse.yasson.defaultmapping.dates.model.DateWithZonePojo;
 import org.eclipse.yasson.defaultmapping.dates.model.InstantPojo;
 import org.eclipse.yasson.defaultmapping.dates.model.LocalDatePojo;
 import org.eclipse.yasson.defaultmapping.dates.model.LocalDateTimePojo;
@@ -148,6 +149,17 @@ public class DatesTest {
         assertEquals(parsedDate, result.millisFormatted);
     }
 
+    @Test
+    public void testDateWithZone() throws ParseException {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
+    	
+    	String jsonDateWithZone = "{\"dateWithZone\":\"2018-11-02T00:00:00+01:00\"}";
+    	final DateWithZonePojo result = jsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
+    	
+    	assertEquals(parsedDate, result.dateWithZone);
+    }
+    
     @Test
     public void testCalendar() {
         final Calendar timeCalendar = new Calendar.Builder()

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/model/DateWithZonePojo.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/model/DateWithZonePojo.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Roman Grigoriadi
+ ******************************************************************************/
+
+package org.eclipse.yasson.defaultmapping.dates.model;
+
+import java.util.Date;
+
+/**
+ * @author Dennis Kriechel
+ */
+public class DateWithZonePojo extends AbstractDateTimePojo<Date> {
+
+    public DateWithZonePojo() {
+    }
+
+    public DateWithZonePojo(Date dateObj) {
+        super(dateObj);
+        this.dateWithZone = dateObj;
+    }
+
+    public Date dateWithZone;
+}


### PR DESCRIPTION
I've changed the implementation of the DateTypeDeserializer to not always use the "withZone(UTC)" since this is producing problem in JDK 8 (see https://github.com/eclipse-ee4j/yasson/issues/172). 

Now, at first it will check if the jsonValue is containing an offset. If true, `withZone(UTC)` is not added. Only if there is no offset, the `withZone(UTC)` is added to the DateFormat.

This should work in both, JDK 8 and 9. I've tested it with JDK 8 and JDK 11 (I don't have JDK 9 currently installed).