### PR TITLE
Change org.glassfish:javax.json to optional compile dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,8 @@
                 <artifactId>jakarta.json</artifactId>
                 <version>${jakarta.json.version}</version>
                 <classifier>module</classifier>
-                <scope>test</scope>
+                <scope>compile</scope>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>


### PR DESCRIPTION
If I want to use Yasson in one of my projects, the normal way to do so is to include the dependency in my pom like this:

```xml
		<dependency>
			<groupId>org.eclipse</groupId>
			<artifactId>yasson</artifactId>
			<version>1.0.1</version>
		</dependency>
```

However, since Yasson does not declare a dependency on any JSON-P implementation, the most simple usage of JSON-B fails with the following:

```
javax.json.JsonException: Provider org.glassfish.json.JsonProviderImpl not found
	at java.json/javax.json.spi.JsonProvider.provider(JsonProvider.java:99)
	at org.eclipse.yasson.internal.JsonBinding$$Lambda$38.000000000D4F5CC0.get(Unknown Source)
	at java.base/java.util.Optional.orElseGet(Optional.java:369)
	at org.eclipse.yasson/org.eclipse.yasson.internal.JsonBinding.<init>(JsonBinding.java:41)
```

I think Yasson should be a bit more opinionated, and include some sort of JSON-P implementation by default. If the user does not want it, they can always exclude Glassfish Json, and put in their own implementation.  However, I expect this to be a rare case.  In most situations, people will not care what JSON-P implementation is used.