### PR TITLE
fixes #247: adding support for char[]

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/CharArrayDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/CharArrayDeserializer.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Roman Grigoriadi
+ ******************************************************************************/
+
+package org.eclipse.yasson.internal.serializer;
+
+import org.eclipse.yasson.internal.Unmarshaller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Array unmarshaller item implementation for char.
+ *
+ * @author Bernd Zeitler
+ */
+public class CharArrayDeserializer extends AbstractArrayDeserializer<char[]> {
+
+    private final List<Character> items = new ArrayList<>();
+
+    protected CharArrayDeserializer(DeserializerBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected List<?> getItems() {
+        return items;
+    }
+
+    @Override
+    public char[] getInstance(Unmarshaller unmarshaller) {
+        final int size = items.size();
+        final char[] charArray = new char[size];
+        for(int i=0; i<size; i++) {
+            charArray[i] = items.get(i);
+        }
+        return charArray;
+    }
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/CharArraySerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/CharArraySerializer.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Roman Grigoriadi
+ ******************************************************************************/
+
+package org.eclipse.yasson.internal.serializer;
+
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+
+/**
+ * Serializes byte array as JSON array of ints.
+ *
+ * @author Bernd Zeitler
+ */
+public class CharArraySerializer extends AbstractArraySerializer<char[]> {
+
+    protected CharArraySerializer(SerializerBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected void serializeInternal(char[] obj, JsonGenerator generator, SerializationContext ctx) {
+        for (char c : obj) {
+            generator.write("" + c); // this is a hack, but e.g. org.glassfish.json.api.JsonGeneratorImpl does not support writing a char
+        }
+    }
+
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
@@ -151,6 +151,10 @@ public class DeserializerBuilder extends AbstractSerializerBuilder<DeserializerB
             }
         }
 
+        if (isCharArray(rawType)) {
+            return new CharArrayDeserializer(this);
+        }
+
         //Third deserializer is a supported value type to deserialize to JSON_VALUE
         if (isJsonValueEvent()) {
             final Optional<AbstractValueTypeDeserializer<?>> supportedTypeDeserializer = getSupportedTypeDeserializer(rawType);
@@ -306,5 +310,9 @@ public class DeserializerBuilder extends AbstractSerializerBuilder<DeserializerB
 
     private boolean isByteArray(Class<?> rawType) {
         return rawType.isArray() && rawType.getComponentType() == Byte.TYPE;
+    }
+
+    private boolean isCharArray(Class<?> rawType) {
+        return rawType.isArray() && rawType.getComponentType() == Character.TYPE;
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
@@ -130,6 +130,8 @@ public class SerializerBuilder extends AbstractSerializerBuilder<SerializerBuild
             return new ByteArraySerializer(this);
         } else if (componentType == short.class) {
             return new ShortArraySerializer(this);
+        } else if (componentType == char.class) {
+            return new CharArraySerializer(this);
         } else if (componentType == int.class) {
             return new IntArraySerializer(this);
         } else if (componentType == long.class) {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
@@ -163,6 +163,13 @@ public class ArrayTest {
     }
 
     @Test
+    public void testCharArray() {
+        char[] charArr = {'a', 'b', 'c'};
+        assertEquals("[\"a\",\"b\",\"c\"]", jsonb.toJson(charArr));
+        assertArrayEquals(charArr, jsonb.fromJson("[\"a\",\"b\",\"c\"]", char[].class));
+    }
+
+    @Test
     public void testShortArray() {
         short[] shortArr = {-128, 127};
         assertEquals("[-128,127]", jsonb.toJson(shortArr));


### PR DESCRIPTION
Signed-off-by: Bernd Zeitler <bernd.zeitler@quantentunnel.de>

Adopted the existing code to add support for `char[]`. Used `javax.json.stream.JsonGenerator#write(java.lang.String)` within the serializer, since writing a `char` was not available. The json should look like when using `java.lang.Characater[]`.