### PR TITLE
Unify handling of empty Optional root objects.

### DIFF
--- a/src/main/java/org/eclipse/yasson/YassonProperties.java
+++ b/src/main/java/org/eclipse/yasson/YassonProperties.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/YassonProperties.java
+++ b/src/main/java/org/eclipse/yasson/YassonProperties.java
@@ -35,4 +35,11 @@ public class YassonProperties {
      * to instant {@link java.time.Instant} or {@link java.time.ZonedDateTime}.
      */
     public static final String ZERO_TIME_PARSE_DEFAULTING = "jsonb.zero-time-defaulting";
+
+    /**
+     * Serializer to use when object provided to {@link javax.json.bind.Jsonb#toJson(Object)} is {@code null} or an empty
+     * Optional. Much be instance of {@link javax.json.bind.serializer.JsonbSerializer}{@code <Object>}. Its obj value
+     * will be respective parameter.
+     */
+    public static final String NULL_ROOT_SERIALIZER = "yasson.null-root-serializer";
 }

--- a/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
+++ b/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/internal/Marshaller.java
+++ b/src/main/java/org/eclipse/yasson/internal/Marshaller.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/internal/Marshaller.java
+++ b/src/main/java/org/eclipse/yasson/internal/Marshaller.java
@@ -135,6 +135,10 @@ public class Marshaller extends ProcessingContext implements SerializationContex
      */
     @SuppressWarnings("unchecked")
     public <T> void serializeRoot(T root, JsonGenerator generator) {
+        if (root == null) {
+            getJsonbContext().getConfigProperties().getNullSerializer().serialize(null, generator, this);
+            return;
+        }
         final JsonbSerializer<T> rootSerializer = (JsonbSerializer<T>) getRootSerializer(root.getClass());
         if (jsonbContext.getConfigProperties().isStrictIJson() &&
                 rootSerializer instanceof AbstractValueTypeSerializer) {

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -127,6 +128,9 @@ public class DeserializerBuilder extends AbstractSerializerBuilder<DeserializerB
         if (isJsonValueEvent()) {
             final Optional<AbstractValueTypeDeserializer<?>> supportedTypeDeserializer = getSupportedTypeDeserializer(rawType);
             if (!supportedTypeDeserializer.isPresent()) {
+                if (jsonEvent == JsonParser.Event.VALUE_NULL) {
+                    return NullDeserializer.INSTANCE;
+                }
                 throw new JsonbException(Messages.getMessage(MessageKeys.DESERIALIZE_VALUE_ERROR, getRuntimeType()));
             }
             return wrapAdapted(adapterInfoOptional, supportedTypeDeserializer.get());
@@ -225,6 +229,8 @@ public class DeserializerBuilder extends AbstractSerializerBuilder<DeserializerB
                 return ArrayList.class;
                 case START_OBJECT:
                     return jsonbContext.getConfigProperties().getDefaultMapImplType();
+                case VALUE_NULL:
+                    return Object.class;
                 default:
                 throw new IllegalStateException("Can't infer deserialization type type: " + jsonEvent);
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/NullDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/NullDeserializer.java
@@ -1,0 +1,54 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package org.eclipse.yasson.internal.serializer;
+
+import javax.json.bind.serializer.DeserializationContext;
+import javax.json.bind.serializer.JsonbDeserializer;
+import javax.json.stream.JsonParser;
+import java.lang.reflect.Type;
+
+public enum NullDeserializer implements JsonbDeserializer<Object> {
+    INSTANCE;
+    @Override
+    public Object deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+        return null;
+    }
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/NullSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/NullSerializer.java
@@ -1,0 +1,52 @@
+/*
+ *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) [2019] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *    The contents of this file are subject to the terms of either the GNU
+ *    General Public License Version 2 only ("GPL") or the Common Development
+ *    and Distribution License("CDDL") (collectively, the "License").  You
+ *    may not use this file except in compliance with the License.  You can
+ *    obtain a copy of the License at
+ *    https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *    See the License for the specific
+ *    language governing permissions and limitations under the License.
+ *
+ *    When distributing the software, include this License Header Notice in each
+ *    file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *    GPL Classpath Exception:
+ *    The Payara Foundation designates this particular file as subject to the "Classpath"
+ *    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *    file that accompanied this code.
+ *
+ *    Modifications:
+ *    If applicable, add the following below the License Header, with the fields
+ *    enclosed by brackets [] replaced by your own identifying information:
+ *    "Portions Copyright [year] [name of copyright owner]"
+ *
+ *    Contributor(s):
+ *    If you wish your version of this file to be governed by only the CDDL or
+ *    only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *    elects to include this software in this distribution under the [CDDL or GPL
+ *    Version 2] license."  If you don't indicate a single choice of license, a
+ *    recipient has the option to distribute your version of this file under
+ *    either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *    its licensees as provided above.  However, if you add GPL Version 2 code
+ *    and therefore, elected the GPL Version 2 license, then the option applies
+ *    only if the new code is made subject to such option by the copyright
+ *    holder.
+ */
+
+package org.eclipse.yasson.internal.serializer;
+
+import javax.json.bind.serializer.JsonbSerializer;
+import javax.json.bind.serializer.SerializationContext;
+import javax.json.stream.JsonGenerator;
+
+public class NullSerializer implements JsonbSerializer<Object> {
+    @Override
+    public void serialize(Object obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.writeNull();
+    }
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalDoubleTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalDoubleTypeDeserializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalDoubleTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalDoubleTypeSerializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -19,6 +20,8 @@ import org.eclipse.yasson.internal.model.customization.Customization;
 import javax.json.stream.JsonGenerator;
 import java.util.OptionalDouble;
 
+import static org.eclipse.yasson.internal.serializer.OptionalObjectSerializer.handleEmpty;
+
 /**
  * Serializer for {@link OptionalDouble} type.
  * 
@@ -37,10 +40,8 @@ public class OptionalDoubleTypeSerializer extends AbstractValueTypeSerializer<Op
 
     @Override
     protected void serialize(OptionalDouble obj, JsonGenerator generator, Marshaller marshaller) {
-        if (obj.isPresent()) {
+        if (!handleEmpty(obj, OptionalDouble::isPresent, customization, generator, marshaller)) {
             generator.write(obj.getAsDouble());
-        } else if (customization.isNillable()) {
-            generator.writeNull();
         }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalIntTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalIntTypeSerializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalIntTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalIntTypeSerializer.java
@@ -17,7 +17,10 @@ import org.eclipse.yasson.internal.Marshaller;
 import org.eclipse.yasson.internal.model.customization.Customization;
 
 import javax.json.stream.JsonGenerator;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
+
+import static org.eclipse.yasson.internal.serializer.OptionalObjectSerializer.handleEmpty;
 
 /**
  * Serializer for {@link OptionalInt} type.
@@ -37,10 +40,8 @@ public class OptionalIntTypeSerializer extends AbstractValueTypeSerializer<Optio
 
     @Override
     protected void serialize(OptionalInt obj, JsonGenerator generator, Marshaller marshaller) {
-        if (obj.isPresent()) {
+        if (!handleEmpty(obj, OptionalInt::isPresent, customization, generator, marshaller)) {
             generator.write(obj.getAsInt());
-        } else if (customization != null && customization.isNillable()) {
-            generator.writeNull();
         }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalLongTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalLongTypeSerializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalLongTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalLongTypeSerializer.java
@@ -17,7 +17,10 @@ import org.eclipse.yasson.internal.Marshaller;
 import org.eclipse.yasson.internal.model.customization.Customization;
 
 import javax.json.stream.JsonGenerator;
+import java.util.OptionalDouble;
 import java.util.OptionalLong;
+
+import static org.eclipse.yasson.internal.serializer.OptionalObjectSerializer.handleEmpty;
 
 /**
  * Serializer for {@link OptionalLong} type.
@@ -37,10 +40,8 @@ public class OptionalLongTypeSerializer extends AbstractValueTypeSerializer<Opti
 
     @Override
     protected void serialize(OptionalLong obj, JsonGenerator generator, Marshaller marshaller) {
-        if (obj.isPresent()) {
+        if (!handleEmpty(obj, OptionalLong::isPresent, customization, generator, marshaller)) {
             generator.write(obj.getAsLong());
-        } else if (customization.isNillable()) {
-            generator.writeNull();
         }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalObjectDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalObjectDeserializer.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * Roman Grigoriadi
+ * Patrik Dudits
+ ******************************************************************************/
 package org.eclipse.yasson.internal.serializer;
 
 import org.eclipse.yasson.internal.JsonbContext;
@@ -31,6 +45,9 @@ public class OptionalObjectDeserializer implements JsonbDeserializer<Optional<?>
     public Optional<?> deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
         JsonbContext jsonbContext = ((ProcessingContext) ctx).getJsonbContext();
         final JsonParser.Event lastEvent = ((JsonbParser) parser).getCurrentLevel().getLastEvent();
+        if (lastEvent == JsonParser.Event.VALUE_NULL) {
+            return Optional.empty();
+        }
         JsonbDeserializer deserializer = new DeserializerBuilder(jsonbContext).withType(optionalValueType)
                 .withWrapper(wrapper).withJsonValueType(lastEvent).build();
         return Optional.of(deserializer.deserialize(parser, ctx, optionalValueType));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/OptionalObjectSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/OptionalObjectSerializer.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -13,12 +14,17 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.specific.model.Street;
+import org.eclipse.yasson.internal.JsonBindingBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertNull;
 
@@ -43,4 +49,25 @@ public class NullTest {
         assertNull(result.getName());
         assertNull(result.getNumber());
     }
+
+    @Test
+    public void testDeserializeNull() {
+        assertNull(jsonb.fromJson("null", Object.class));
+    }
+
+    @Test
+    public void testDeserializeNullPojo() {
+        assertNull(jsonb.fromJson("null", Street.class));
+    }
+
+    @Test
+    public void testDeserializeNullList() {
+        assertNull(jsonb.fromJson("null", new TestTypeToken<List<Integer>>() {}.getType()));
+    }
+
+    @Test
+    public void testDeserializeNullMap() {
+        assertNull(jsonb.fromJson("null", new TestTypeToken<Map<String, Street>>() {}.getType()));
+    }
+
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -9,6 +10,7 @@
  *
  * Contributors:
  *     Dmitry Kornilov - initial implementation
+ *     Patrik Dudits
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.specific;
 
@@ -166,6 +168,53 @@ public class OptionalTest {
         assertEquals(personWithCorrectGetter, deserialized);
     }
 
+    @Test
+    public void testMarshalEmptyRoot() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals("null", jsonb.toJson(Optional.empty()));
+    }
+
+    @Test
+    public void testUnmarshalEmptyRoot() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals(Optional.empty(), jsonb.fromJson("null", new TestTypeToken<Optional<Customer>>() {}.getType()));
+    }
+
+    @Test
+    public void testMarshalEmptyInt() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals("null", jsonb.toJson(OptionalInt.empty()));
+    }
+
+    @Test
+    public void testUnmarshalEmptyInt() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals(OptionalInt.empty(), jsonb.fromJson("null", OptionalInt.class));
+    }
+
+    @Test
+    public void testMarshalEmptyLong() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals("null", jsonb.toJson(OptionalLong.empty()));
+    }
+
+    @Test
+    public void testUnmarshalEmptyLong() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals(OptionalLong.empty(), jsonb.fromJson("null", OptionalLong.class));
+    }
+
+    @Test
+    public void testMarshalEmptyDouble() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals("null", jsonb.toJson(OptionalDouble.empty()));
+    }
+
+    @Test
+    public void testUnmarshalEmptyDouble() {
+        final Jsonb jsonb = (new JsonBindingBuilder()).build();
+        assertEquals(OptionalDouble.empty(), jsonb.fromJson("null", OptionalDouble.class));
+    }
 
     public static class Customer {
         private int id;


### PR DESCRIPTION
- empty optionals serialize as null
- null value deserializes into empty Optional

Fixes #263.

Previous behavior was inconsistent:
`Optional<>` throws exception when serializing or deserializing.
`OptionalDouble` and `OptionalLong` throw exception when serializing, deserialize `null` into empty
`OptionalInt` serializes empty as no token, deserialize `null` into empty (but not eof into empty).