### PR TITLE
Revert "number values outside of IEEE754 64bit range"

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/BigDecimalTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/BigDecimalTypeSerializer.java
@@ -36,11 +36,19 @@ public class BigDecimalTypeSerializer extends AbstractNumberSerializer<BigDecima
 
     @Override
     protected void serializeNonFormatted(BigDecimal obj, JsonGenerator generator, String key) {
-        generator.write(key, obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(key, obj);
+        } else {
+            generator.write(key, obj.toString());
+        }
     }
 
     @Override
     protected void serializeNonFormatted(BigDecimal obj, JsonGenerator generator) {
-        generator.write(obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(obj);
+        } else {
+            generator.write(obj.toString());
+        }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/BigIntegerTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/BigIntegerTypeSerializer.java
@@ -36,11 +36,19 @@ public class BigIntegerTypeSerializer extends AbstractNumberSerializer<BigIntege
 
     @Override
     protected void serializeNonFormatted(BigInteger obj, JsonGenerator generator, String key) {
-        generator.write(key, obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(key, obj);
+        } else {
+            generator.write(key, obj.toString());
+        }
     }
 
     @Override
     protected void serializeNonFormatted(BigInteger obj, JsonGenerator generator) {
-        generator.write(obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(obj);
+        } else {
+            generator.write(obj.toString());
+        }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/BigNumberUtil.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/BigNumberUtil.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ * David Kral
+ ******************************************************************************/
+
+package org.eclipse.yasson.internal.serializer;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Utility class for checking of IEEE-754 standard in big numbers
+ *
+ * @author David Kral
+ */
+class BigNumberUtil {
+
+    // 53 means max bit value of number with sign bit included
+    private static final int MAX_BIT_SIZE = 53;
+
+    // Max value for Long. Similar to JavaScript Number.MAX_SAFE_INTEGER (2**53)-1
+    private static final long MAX_JS_SAFE_VALUE = 9007199254740991L;
+
+    // Min value for Long. Similar to JavaScript Number.MIN_SAFE_INTEGER -(2**53)+1
+    private static final long MIN_JS_SAFE_VALUE = -9007199254740991L;
+
+    // -1022 is the lowest range of the exponent
+    // more https://en.wikipedia.org/wiki/Exponent_bias
+    private static final int MIN_RANGE = -1022;
+
+    // 1023 is the highest range of the exponent
+    // more https://en.wikipedia.org/wiki/Exponent_bias
+    private static final int MAX_RANGE = 1023;
+
+    /**
+     * Checks whether the value of {@link BigDecimal} matches format IEEE-754
+     *
+     * @param value value which is going to be checked
+     * @return true if value matches format IEEE-754
+     */
+    static boolean isIEEE754(BigDecimal value) {
+        //scale of the number
+        int scale = value.scale();
+        //bit value of number without scale
+        int valBits = value.unscaledValue().abs().bitLength();
+        //bit value of scaled number
+        int intBitsScaled = value.toBigInteger().bitLength();
+        // Number whose bit length is than 53 or is not in range is considered as non IEEE 754-2008 binary64 compliant
+        return valBits <= MAX_BIT_SIZE && intBitsScaled <= MAX_BIT_SIZE && MIN_RANGE <= scale && scale <= MAX_RANGE;
+    }
+
+    /**
+     * Checks whether the value of {@link BigInteger} matches format IEEE-754
+     *
+     * @param value value which is going to be checked
+     * @return true if value matches format IEEE-754
+     */
+    static boolean isIEEE754(BigInteger value) {
+        // Number whose bit length is than 53 is considered as non IEEE 754-2008 binary64 compliant
+        return value.abs().bitLength() <= MAX_BIT_SIZE;
+    }
+
+    /**
+     * Checks whether the value of {@link Long} matches format IEEE-754
+     *
+     * @param value value which is going to be checked
+     * @return true if value matches format IEEE-754
+     */
+    static boolean isIEEE754(Long value) {
+        return value >= MIN_JS_SAFE_VALUE && value <= MAX_JS_SAFE_VALUE;
+    }
+
+
+
+}

--- a/src/main/java/org/eclipse/yasson/internal/serializer/LongTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/LongTypeSerializer.java
@@ -35,11 +35,19 @@ public class LongTypeSerializer extends AbstractNumberSerializer<Long> {
 
     @Override
     protected void serializeNonFormatted(Long obj, JsonGenerator generator, String key) {
-        generator.write(key, obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(key, obj);
+        } else {
+            generator.write(key, obj.toString());
+        }
     }
 
     @Override
     protected void serializeNonFormatted(Long obj, JsonGenerator generator) {
-        generator.write(obj);
+        if (BigNumberUtil.isIEEE754(obj)) {
+            generator.write(obj);
+        } else {
+            generator.write(obj.toString());
+        }
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/NumberTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/NumberTypeSerializer.java
@@ -38,6 +38,10 @@ public class NumberTypeSerializer extends AbstractValueTypeSerializer<Number> {
     @Override
     protected void serialize(Number obj, JsonGenerator generator, Marshaller marshaller) {
         BigDecimal bigDecimalValue = new BigDecimal(String.valueOf(obj));
-        generator.write(bigDecimalValue);
+        if (BigNumberUtil.isIEEE754(bigDecimalValue)) {
+            generator.write(bigDecimalValue);
+        } else {
+            generator.write(String.valueOf(obj));
+        }
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
@@ -50,7 +50,7 @@ public class NumberTest {
     @Test
     public void testBigDecimalMarshalling() {
         String jsonString = jsonb.toJson(new BigDecimal("0.10000000000000001"));
-        Assert.assertEquals("0.10000000000000001", jsonString);
+        Assert.assertEquals("\"0.10000000000000001\"", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("0.1000000000000001"));
         Assert.assertEquals("0.1000000000000001", jsonString);
@@ -58,7 +58,7 @@ public class NumberTest {
         BigDecimal result = jsonb.fromJson("0.10000000000000001", BigDecimal.class);
         Assert.assertEquals(new BigDecimal("0.10000000000000001"), result);
 
-        result = jsonb.fromJson("0.100000000000000001", BigDecimal.class);
+        result = jsonb.fromJson("\"0.100000000000000001\"", BigDecimal.class);
         Assert.assertEquals(new BigDecimal("0.100000000000000001"), result);
     }
 
@@ -68,13 +68,13 @@ public class NumberTest {
         Assert.assertEquals("9007199254740991", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("9007199254740992"));
-        Assert.assertEquals("9007199254740992", jsonString);
+        Assert.assertEquals("\"9007199254740992\"", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("9007199254740991.1"));
-        Assert.assertEquals("9007199254740991.1", jsonString);
+        Assert.assertEquals("\"9007199254740991.1\"", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal(new BigInteger("1"), -400));
-        Assert.assertEquals(new BigDecimal(new BigInteger("1"), -400).toString(), jsonString);
+        Assert.assertEquals("\"" + new BigDecimal(new BigInteger("1"), -400) + "\"", jsonString);
     }
 
     @Test
@@ -83,7 +83,7 @@ public class NumberTest {
         Assert.assertEquals("9007199254740991", jsonString);
 
         jsonString = jsonb.toJson(new BigInteger("9007199254740992"));
-        Assert.assertEquals("9007199254740992", jsonString);
+        Assert.assertEquals("\"9007199254740992\"", jsonString);
     }
 
     @Test
@@ -91,12 +91,12 @@ public class NumberTest {
         BigDecimalInNumber testValueQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740992"));}};
         BigDecimalInNumber testValueUnQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740991"));}};
         String jsonString = jsonb.toJson(testValueQuoted);
-        Assert.assertEquals("{\"bigDecValue\":9007199254740992}", jsonString);
+        Assert.assertEquals("{\"bigDecValue\":\"9007199254740992\"}", jsonString);
 
         jsonString = jsonb.toJson(testValueUnQuoted);
         Assert.assertEquals("{\"bigDecValue\":9007199254740991}", jsonString);
 
-        BigDecimalInNumber result = jsonb.fromJson("{\"bigDecValue\":9007199254740992}", BigDecimalInNumber.class);
+        BigDecimalInNumber result = jsonb.fromJson("{\"bigDecValue\":\"9007199254740992\"}", BigDecimalInNumber.class);
         Assert.assertEquals(testValueQuoted.getBigDecValue(), result.getBigDecValue());
 
         result = jsonb.fromJson("{\"bigDecValue\":9007199254740991}", BigDecimalInNumber.class);
@@ -109,19 +109,19 @@ public class NumberTest {
         Assert.assertEquals("{\"value\":0.1000000000000001}", jsonString);
 
         jsonString = jsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.10000000000000001")));
-        Assert.assertEquals("{\"value\":0.10000000000000001}", jsonString);
+        Assert.assertEquals("{\"value\":\"0.10000000000000001\"}", jsonString);
 
         ScalarValueWrapper<BigDecimal> result = jsonb.fromJson("{\"value\":0.1000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
         Assert.assertEquals(new BigDecimal("0.1000000000000001"), result.getValue());
 
-        result = jsonb.fromJson("{\"value\":0.10000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
+        result = jsonb.fromJson("{\"value\":\"0.10000000000000001\"}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
         Assert.assertEquals(new BigDecimal("0.10000000000000001"), result.getValue());
     }
 
     @Test
     public void testBigDecimalCastedToNumber() {
         String jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.10000000000000001"); });
-        Assert.assertEquals("{\"number\":0.10000000000000001}", jsonString);
+        Assert.assertEquals("{\"number\":\"0.10000000000000001\"}", jsonString);
 
         jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.1000000000000001"); });
         Assert.assertEquals("{\"number\":0.1000000000000001}", jsonString);
@@ -140,7 +140,7 @@ public class NumberTest {
         Assert.assertEquals(Long.valueOf("9007199254740991"), deserialized);
 
         json = jsonb.toJson(upperJsUnsafeValue);
-        Assert.assertEquals("9007199254740992", json);
+        Assert.assertEquals("\"9007199254740992\"", json);
         deserialized = jsonb.fromJson(json, Long.class);
         Assert.assertEquals(Long.valueOf("9007199254740992"), deserialized);
 
@@ -154,7 +154,7 @@ public class NumberTest {
         Assert.assertEquals(Long.valueOf("-9007199254740991"), deserialized);
 
         json = jsonb.toJson(lowerJsUnsafeValue);
-        Assert.assertEquals("-9007199254740992", json);
+        Assert.assertEquals("\"-9007199254740992\"", json);
         deserialized = jsonb.fromJson(json, Long.class);
         Assert.assertEquals(Long.valueOf("-9007199254740992"), deserialized);
     }


### PR DESCRIPTION
Revert "Removed stringification for number values outside of IEEE754 64bit range."

This reverts commit d2b8ce31

We need to revert this commit because of it does break TCK tests. We might apply it again in future when proper fix is found, but simple removal of this feature does not solve anything.