### PR TITLE
316 improve exception message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 .classpath
 .project
+.idea/
 .settings/
 /.DS_Store

--- a/src/main/java/org/eclipse/yasson/internal/ReflectionUtils.java
+++ b/src/main/java/org/eclipse/yasson/internal/ReflectionUtils.java
@@ -210,7 +210,9 @@ public class ReflectionUtils {
      * Get default no argument constructor of the class.
      * @param clazz Class to get constructor from
      * @param <T> Class generic type
-     * @return constructor
+     * @param required if true, throws an exception if the default constructor is missing.
+     *                 If false, returns null in that case
+     * @return the constructor of the class, or null. Depending on required.
      */
     public static <T> Constructor<T> getDefaultConstructor(Class<T> clazz, boolean required) {
         Objects.requireNonNull(clazz);

--- a/src/main/java/org/eclipse/yasson/internal/serializer/ObjectDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/ObjectDeserializer.java
@@ -87,9 +87,15 @@ class ObjectDeserializer<T> extends AbstractContainerDeserializer<T> {
         }
         final Class<?> rawType = ReflectionUtils.getRawType(getRuntimeType());
         final JsonbCreator creator = getClassModel().getClassCustomization().getCreator();
-        instance = creator != null ? createInstance((Class<T>) rawType, creator)
-                : ReflectionUtils.createNoArgConstructorInstance((Constructor<T>) getClassModel().getDefaultConstructor());
-
+        if (creator != null) {
+            instance = createInstance((Class<T>) rawType, creator);
+        } else {
+            Constructor<T> defaultConstructor = (Constructor<T>) getClassModel().getDefaultConstructor();
+            if (defaultConstructor == null) {
+                throw new JsonbException(Messages.getMessage(MessageKeys.NO_DEFAULT_CONSTRUCTOR, rawType));
+            }
+            instance = ReflectionUtils.createNoArgConstructorInstance(defaultConstructor);
+        }
         //values must be set in order, in which they appears in JSON by spec
         values.forEach((key, wrapper) -> {
             //skip creator values

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
+import javax.json.bind.JsonbException;
 
 public class ObjectDeserializerTest {
 
@@ -14,8 +15,8 @@ public class ObjectDeserializerTest {
 
     @Test
     public void testGetInstanceExceptionShouldContainClassNameOnMissingConstructor() {
-        expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("org.eclipse.yasson.internal.serializer.ObjectDeserializerTest$DummyDeserializationClass");
+        expectedException.expect(JsonbException.class);
+        expectedException.expectMessage(DummyDeserializationClass.class.getName());
 
         Jsonb jsonb = JsonbBuilder.create();
         jsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class);

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -1,0 +1,39 @@
+package org.eclipse.yasson.internal.serializer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+public class ObjectDeserializerTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testGetInstanceExceptionShouldContainClassNameOnMissingConstructor() {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("org.eclipse.yasson.internal.serializer.ObjectDeserializerTest$DummyDeserializationClass");
+
+        Jsonb jsonb = JsonbBuilder.create();
+        jsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class);
+    }
+
+    public static class DummyDeserializationClass {
+        private String key;
+
+        public DummyDeserializationClass(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+    }
+}


### PR DESCRIPTION
Fixing https://github.com/eclipse-ee4j/yasson/issues/316

Adding the name of the class to the Exception message when the default constructor is missing.