### PR TITLE
Improve Recursive Serialisation Behaviour

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/model/PropertyModel.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/PropertyModel.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -8,7 +10,8 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- * Roman Grigoriadi
+ *  Roman Grigoriadi
+ *  Payara Services - Added default serialiser to user serializer
  ******************************************************************************/
 package org.eclipse.yasson.internal.model;
 
@@ -23,6 +26,7 @@ import org.eclipse.yasson.internal.serializer.AdaptedObjectSerializer;
 import org.eclipse.yasson.internal.serializer.DefaultSerializers;
 import org.eclipse.yasson.internal.serializer.JsonbDateFormatter;
 import org.eclipse.yasson.internal.serializer.JsonbNumberFormatter;
+import org.eclipse.yasson.internal.serializer.ObjectSerializer;
 import org.eclipse.yasson.internal.serializer.SerializerProviderWrapper;
 import org.eclipse.yasson.internal.serializer.UserSerializerSerializer;
 
@@ -117,7 +121,7 @@ public class PropertyModel implements Comparable<PropertyModel> {
             return new AdaptedObjectSerializer<>(classModel, customization.getSerializeAdapterBinding());
         }
         if (customization.getSerializerBinding() != null) {
-            return new UserSerializerSerializer<>(classModel, customization.getSerializerBinding().getJsonbSerializer());
+            return new UserSerializerSerializer<>(customization.getSerializerBinding().getJsonbSerializer(), new ObjectSerializer<>(null, propertyType, classModel));
         }
 
         final Class<?> propertyRawType = ReflectionUtils.getRawType(serializationType);
@@ -148,7 +152,7 @@ public class PropertyModel implements Comparable<PropertyModel> {
     }
 
     private SerializerBinding<?> getUserSerializerBinding(Property property, JsonbContext jsonbContext) {
-        final SerializerBinding serializerBinding = jsonbContext.getAnnotationIntrospector().getSerializerBinding(property);
+        final SerializerBinding<?> serializerBinding = jsonbContext.getAnnotationIntrospector().getSerializerBinding(property);
         if (serializerBinding != null) {
             return serializerBinding;
         }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -8,7 +10,8 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- * Roman Grigoriadi
+ *  Roman Grigoriadi
+ *  Payara Services - Added default serialiser to user serializer
  ******************************************************************************/
 package org.eclipse.yasson.internal.serializer;
 
@@ -71,7 +74,7 @@ public class SerializerBuilder extends AbstractSerializerBuilder<SerializerBuild
             final ComponentMatcher componentMatcher = jsonbContext.getComponentMatcher();
             Optional<SerializerBinding<?>> userSerializer = componentMatcher.getSerializerBinding(getRuntimeType(), customization);
             if (userSerializer.isPresent()) {
-                return new UserSerializerSerializer<>(classModel, userSerializer.get().getJsonbSerializer());
+                return new UserSerializerSerializer<>(userSerializer.get().getJsonbSerializer(), new ObjectSerializer<>(this));
             }
 
             //Second user components is registered.
@@ -140,7 +143,7 @@ public class SerializerBuilder extends AbstractSerializerBuilder<SerializerBuild
         } else if (componentType == double.class) {
             return new DoubleArraySerializer(this);
         } else {
-            return new ObjectArraySerializer(this);
+            return new ObjectArraySerializer<>(this);
         }
     }
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/UserSerializerSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/UserSerializerSerializer.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -8,21 +10,17 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- * Roman Grigoriadi
+ *  Roman Grigoriadi
+ *  Payara Services - Added default serializer
  ******************************************************************************/
 
 package org.eclipse.yasson.internal.serializer;
 
-import org.eclipse.yasson.internal.Marshaller;
-import org.eclipse.yasson.internal.ProcessingContext;
-import org.eclipse.yasson.internal.model.ClassModel;
-import org.eclipse.yasson.internal.properties.MessageKeys;
-import org.eclipse.yasson.internal.properties.Messages;
-
-import javax.json.bind.JsonbException;
 import javax.json.bind.serializer.JsonbSerializer;
 import javax.json.bind.serializer.SerializationContext;
 import javax.json.stream.JsonGenerator;
+
+import org.eclipse.yasson.internal.Marshaller;
 
 /**
  * Serializes an object with user defined serializer.
@@ -34,27 +32,27 @@ public class UserSerializerSerializer<T> implements JsonbSerializer<T> {
 
     private final JsonbSerializer<T> userSerializer;
 
-    private final ClassModel classModel;
+    private final JsonbSerializer<T> defaultSerializer;
 
     /**
      * Create instance of current item with its builder.
      *
-     * @param classModel model
      * @param userSerializer user serializer
+     * @param defaultSerializer serializer to use if the object has already been processed by the user serializer
      */
-    public UserSerializerSerializer(ClassModel classModel, JsonbSerializer<T> userSerializer) {
-        this.classModel = classModel;
+    public UserSerializerSerializer(JsonbSerializer<T> userSerializer, JsonbSerializer<T> defaultSerializer) {
         this.userSerializer = userSerializer;
+        this.defaultSerializer = defaultSerializer;
     }
 
     @Override
     public void serialize(T obj, JsonGenerator generator, SerializationContext ctx) {
-        ProcessingContext context = (Marshaller) ctx;
+        Marshaller context = (Marshaller) ctx;
         try {
             if (context.addProcessedObject(obj)) {
                 userSerializer.serialize(obj, generator, ctx);
             } else {
-                throw new JsonbException(Messages.getMessage(MessageKeys.RECURSIVE_REFERENCE, obj.getClass()));
+                defaultSerializer.serialize(obj, generator, ctx);
             }
         } finally {
             context.removeProcessedObject(obj);

--- a/src/test/java/org/eclipse/yasson/defaultmapping/recursive/RecursionTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/recursive/RecursionTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Payara Services and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *  Payara Services - initial implementation
+ ******************************************************************************/
+package org.eclipse.yasson.defaultmapping.recursive;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import javax.json.bind.Jsonb;
+
+import org.eclipse.yasson.internal.JsonBindingBuilder;
+import org.eclipse.yasson.serializers.model.RecursiveObject;
+import org.junit.Test;
+
+
+/**
+ * Testing for recursive object mapping
+ *
+ * @author Matt Gill
+ */
+public class RecursionTest {
+
+    private static final RecursiveObject OBJECT = RecursiveObject.construct(5);
+    private static final String OBJECT_STRING = "{\"child\":{\"child\":{\"child\":{\"child\":{\"child\":{\"id\":1}}}}}}";
+
+    private final Jsonb jsonb = (new JsonBindingBuilder()).build();
+
+    @Test
+    public void testRecursiveObjectSerialisation() throws IOException {
+        assertEquals(OBJECT_STRING, jsonb.toJson(OBJECT));
+    }
+
+    @Test
+    public void testRecursiveObjectDeserialisation() throws IOException {
+        assertEquals(OBJECT, jsonb.fromJson(OBJECT_STRING, RecursiveObject.class));
+    }
+
+}
+

--- a/src/test/java/org/eclipse/yasson/defaultmapping/recursive/RecursionTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/recursive/RecursionTest.java
@@ -33,6 +33,12 @@ public class RecursionTest {
     private static final RecursiveObject OBJECT = RecursiveObject.construct(5);
     private static final String OBJECT_STRING = "{\"child\":{\"child\":{\"child\":{\"child\":{\"child\":{\"id\":1}}}}}}";
 
+    private static final String[][][][] ARRAY = new String[1][1][1][1];
+    static {
+        ARRAY[0][0][0][0] = "Hello World";
+    }
+    private static final String ARRAY_STRING = "[[[[\"Hello World\"]]]]";
+
     private final Jsonb jsonb = (new JsonBindingBuilder()).build();
 
     @Test
@@ -43,6 +49,16 @@ public class RecursionTest {
     @Test
     public void testRecursiveObjectDeserialisation() throws IOException {
         assertEquals(OBJECT, jsonb.fromJson(OBJECT_STRING, RecursiveObject.class));
+    }
+
+    @Test
+    public void testRecursiveArraySerialisation() throws IOException {
+        assertEquals(ARRAY_STRING, jsonb.toJson(ARRAY));
+    }
+
+    @Test
+    public void testRecursiveArrayDeserialisation() throws IOException {
+        assertEquals(ARRAY, jsonb.fromJson(ARRAY_STRING, String[][][][].class));
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -8,8 +10,9 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- * Roman Grigoriadi
- * Sebastien Rius
+ *  Roman Grigoriadi
+ *  Sebastien Rius
+ *  Payara Services - Corrected recursive serialiser functionality
  ******************************************************************************/
 
 package org.eclipse.yasson.serializers;
@@ -33,7 +36,6 @@ import javax.json.JsonObject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
-import javax.json.bind.JsonbException;
 import javax.json.bind.config.PropertyOrderStrategy;
 import javax.json.bind.serializer.DeserializationContext;
 import javax.json.bind.serializer.JsonbDeserializer;
@@ -54,7 +56,6 @@ import org.eclipse.yasson.serializers.model.CrateJsonObjectDeserializer;
 import org.eclipse.yasson.serializers.model.CrateSerializer;
 import org.eclipse.yasson.serializers.model.CrateSerializerWithConversion;
 import org.eclipse.yasson.serializers.model.GenericPropertyPojo;
-import org.eclipse.yasson.serializers.model.GenericPropertyPojoSerializer;
 import org.eclipse.yasson.serializers.model.NumberDeserializer;
 import org.eclipse.yasson.serializers.model.NumberSerializer;
 import org.eclipse.yasson.serializers.model.RecursiveDeserializer;
@@ -322,15 +323,14 @@ public class SerializersTest {
      */
     @Test
     public void testRecursiveSerializer() {
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withSerializers(new RecursiveSerializer()).withDeserializers(new RecursiveDeserializer()));
+        Jsonb jsonb = JsonbBuilder
+                .create(new JsonbConfig()
+                        .withSerializers(new RecursiveSerializer())
+                .withDeserializers(new RecursiveDeserializer()));
 
         Box box = new Box();
         box.boxStr = "Box to serialize";
-        try {
-            jsonb.toJson(box);
-            fail();
-        } catch (JsonbException ex) {
-        }
+        assertEquals("{\"boxFieldName\":{\"boxStr\":\"Box to serialize\"}}", jsonb.toJson(box));
 
         try {
             jsonb.fromJson("{\"boxStr\":\"Box to deserialize\"}", Box.class);

--- a/src/test/java/org/eclipse/yasson/serializers/model/RecursiveObject.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/RecursiveObject.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Payara Services and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *  Payara Services - initial implementation
+ ******************************************************************************/
+package org.eclipse.yasson.serializers.model;
+
+/**
+ * @author Matt Gill
+ */
+public class RecursiveObject {
+
+    public Integer id;
+
+    public RecursiveObject child;
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((child == null) ? 0 : child.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RecursiveObject other = (RecursiveObject) obj;
+        if (child == null) {
+            if (other.child != null)
+                return false;
+        } else if (!child.equals(other.child))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        return true;
+    }
+
+    public static RecursiveObject construct(int depth) {
+        RecursiveObject object = new RecursiveObject();
+        RecursiveObject parent = object;
+        for (int i = 0; i < depth; i++) {
+            parent.child = new RecursiveObject();
+            parent = parent.child;
+        }
+        parent.id = 1;
+        return object;
+    }
+}


### PR DESCRIPTION
See commit messages for details. Briefly: the current behaviour when encountering recursive serializers (see https://github.com/eclipse-ee4j/yasson/issues/187) is to throw an exception. I see why this is done, but I think this behaviour (of allowing it but falling back to the default object serializer) is an improvement.