### PR TITLE
Optimize some stuff around PropertyOrdering

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
+++ b/src/main/java/org/eclipse/yasson/internal/JsonbConfigProperties.java
@@ -35,7 +35,6 @@ import javax.json.bind.serializer.JsonbSerializer;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +42,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 /**
  * Resolved properties from JSONB config.
@@ -156,7 +155,7 @@ public class JsonbConfigProperties {
         }).orElse(JsonbDateFormat.DEFAULT_FORMAT);
     }
 
-    private Function<Collection<PropertyModel>, List<PropertyModel>> initOrderStrategy() {
+    private Consumer<List<PropertyModel>> initOrderStrategy() {
         Optional<String> strategy = getPropertyOrderStrategy();
         
         return strategy.map(StrategiesProvider::getOrderingFunction)

--- a/src/main/java/org/eclipse/yasson/internal/model/customization/PropertyOrdering.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/customization/PropertyOrdering.java
@@ -28,14 +28,14 @@ import javax.json.bind.config.PropertyOrderStrategy;
  */
 public class PropertyOrdering {
 
-    private final Function<Collection<PropertyModel>, List<PropertyModel>> propertyOrderStrategy;
+    private final Consumer<List<PropertyModel>> propertyOrderStrategy;
 
     /**
      * Creates a new instance.
      *
      * @param propertyOrderStrategy Property order strategy. Must be not null.
      */
-    public PropertyOrdering(Function<Collection<PropertyModel>, List<PropertyModel>> propertyOrderStrategy) {
+    public PropertyOrdering(Consumer<List<PropertyModel>> propertyOrderStrategy) {
         this.propertyOrderStrategy = Objects.requireNonNull(propertyOrderStrategy);
     }
 
@@ -49,7 +49,7 @@ public class PropertyOrdering {
      */
     public List<PropertyModel> orderProperties(List<PropertyModel> properties, ClassModel classModel) {
         Map<String, PropertyModel> byReadName = new HashMap<>();
-        properties.stream().forEach(propertyModel -> byReadName.put(propertyModel.getPropertyName(), propertyModel));
+        properties.forEach(propertyModel -> byReadName.put(propertyModel.getPropertyName(), propertyModel));
 
         String[] order = classModel.getClassCustomization().getPropertyOrder();
         List<PropertyModel> sortedProperties = new ArrayList<>();
@@ -63,7 +63,9 @@ public class PropertyOrdering {
             }
         }
 
-        sortedProperties.addAll(propertyOrderStrategy.apply(byReadName.values()));
+        List<PropertyModel> readNamesToSort = new ArrayList<>(byReadName.values());
+        propertyOrderStrategy.accept(readNamesToSort);
+        sortedProperties.addAll(readNamesToSort);
         return sortedProperties;
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/model/customization/StrategiesProvider.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/customization/StrategiesProvider.java
@@ -12,7 +12,6 @@
  ******************************************************************************/
 package org.eclipse.yasson.internal.model.customization;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.Comparator.comparing;
 import static javax.json.bind.config.PropertyNamingStrategy.*;
 import static javax.json.bind.config.PropertyOrderStrategy.*;
@@ -24,7 +23,7 @@ import org.eclipse.yasson.internal.properties.Messages;
 import org.eclipse.yasson.internal.properties.MessageKeys;
 
 import java.nio.CharBuffer;
-import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.*;
 
 public final class StrategiesProvider {
@@ -32,14 +31,14 @@ public final class StrategiesProvider {
     
     public static final PropertyNamingStrategy CASE_INSENSITIVE_STRATEGY = Objects::requireNonNull;
     
-    public static Function<Collection<PropertyModel>, List<PropertyModel>> getOrderingFunction(String strategy){
+    public static Consumer<List<PropertyModel>> getOrderingFunction(String strategy){
         switch(strategy) {
             case LEXICOGRAPHICAL:
-            	return createSortingOrdererFunction(comparing(PropertyModel::getWriteName));
+            	return props -> props.sort(comparing(PropertyModel::getWriteName));
             case ANY:
-            	return ArrayList::new;
+            	return props -> {};
             case REVERSE:
-            	return createSortingOrdererFunction(comparing(PropertyModel::getWriteName).reversed());
+            	return props -> props.sort(comparing(PropertyModel::getWriteName).reversed());
             default:
             	throw new JsonbException(Messages.getMessage(MessageKeys.PROPERTY_ORDER, strategy));
         }
@@ -64,10 +63,6 @@ public final class StrategiesProvider {
         }
     }
     
-    
-    private static Function<Collection<PropertyModel>, List<PropertyModel>> createSortingOrdererFunction(Comparator<PropertyModel> comparator){
-        return props -> props.stream().sorted(comparator).collect(toList());
-    }
     
     private static PropertyNamingStrategy createUpperCamelCaseStrategy() {
         return propertyName -> {


### PR DESCRIPTION
- Replace a '.stream.forEach()' with a normal '.forEach' call in PropertyOrdering.orderProperties
- Rework all ordering functions, so that the list copying happens in PropertyOrdering.orderProperties(). This makes it possible to replace all stream().sorted calls with List.sort() calls in StrategiesProvider.getOrderingFunction().
- Remove StrategiesProvider.createSortingOrdererFunction.

Signed-off-by: Gyúróczki Gergő <gergonoorbi@gmail.com>