### PR TITLE
Avoid contractions in NLS messages

### DIFF
--- a/src/main/resources/yasson-messages.properties
+++ b/src/main/resources/yasson-messages.properties
@@ -11,45 +11,48 @@
 # Roman Grigoriadi
 # David Kral
 ################################################################################
+# The following 2 comment lines are for automated tools that the IBM translation teams use
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
 
-cannotMarshallObject = Cannot marshall object
-typeResolutionError = Error resolving runtime type for type: {0}
-genericBoundNotFound = Generic bound not found for type {0} declared in {1}.
-cantConvertJsonValue = Can'''t convert JSON value into: {0}
-cantCreateRootInstance = Can'''t create root instance
-invokingGetter = Error invoking getter method.
-gettingValue = Error getting field value.
-settingValue = Error setting field value.
-noLoggerName = Logger name has to be set
-resolveParametrizedType = Can''t resolve ParameterizedType superclass for: {0}
-cantCreateInstance = Can''t create instance
-inferTypeForUnmarshall = Can''t infer a type for unmarshalling into: {0}
-implClassIncompatible = Implementation class {0} is not a subtype of interface {1}.
-notValueType = Not a value type: {0}
-unexpectedParseEvent = Unexpected parser event: {0}
-processFromJson = Process class: {0} from json using converter: {1}
-processToJson = Process class: {0} to json using converter: {1}
-creatingHandles = Error creating handles.
-settingValueWith = Error setting value with: {0}
-gettingValueWith = Error getting value with: {0}
-unpairedSurrogate = String contains unpaired surrogate.
-adapterException = Problem adapting object of type {0} to {1} in class {2}
-adapterFound = Found adapter from type {0} to type {1}.
-adapterIncompatible = Adapter of runtime type {0} does not match property type {1}
-propertyOrder = "Property order strategy with name {0} wasn't recognized"
+cannotMarshallObject=Cannot marshall object
+typeResolutionError=Error resolving runtime type for type: {0}
+genericBoundNotFound=Generic bound not found for type {0} declared in {1}.
+cantConvertJsonValue=Cannot convert JSON value into: {0}
+cantCreateRootInstance=Cannot create root instance
+invokingGetter=Error invoking getter method.
+gettingValue=Error getting field value.
+settingValue=Error setting field value.
+noLoggerName=Logger name has to be set
+resolveParametrizedType=Cannot resolve ParameterizedType superclass for: {0}
+cantCreateInstance=Cannot create instance
+inferTypeForUnmarshall=Cannot infer a type for unmarshalling into: {0}
+implClassIncompatible=Implementation class {0} is not a subtype of interface {1}.
+notValueType=Not a value type: {0}
+unexpectedParseEvent=Unexpected parser event: {0}
+processFromJson=Process class: {0} from json using converter: {1}
+processToJson=Process class: {0} to json using converter: {1}
+creatingHandles=Error creating handles.
+settingValueWith=Error setting value with: {0}
+gettingValueWith=Error getting value with: {0}
+unpairedSurrogate=String contains unpaired surrogate.
+adapterException=Problem adapting object of type {0} to {1} in class {2}
+adapterFound=Found adapter from type {0} to type {1}.
+adapterIncompatible=Adapter of runtime type {0} does not match property type {1}
+propertyOrder=Property order strategy with name {0} was not recognized
 unsupportedJsonpSerializerValue=Unsupported value of type {0} for JSON serializer.
 noJndiEnvironment=No JNDI environment ({0}) found to look for CDI provider.
 noCdiApiProvider=CDI API not found on class or module path {0}.
-illegalAccess=Yasson doesn''t have sufficient permissions to {0}.
+illegalAccess=Yasson does not have sufficient permissions to {0}.
 usingDefaultConstructorInstantiator=CDI bean manager not found, serializers and adapters will not have CDI support.
 noCdiEnvironment=CDI environment is not available.
-iJsonEnabledSingleValue = Cannot marshal single value because I-Json is enabled!
+iJsonEnabledSingleValue=Cannot marshal single value because I-Json is enabled!
 dateTypeNotSupported=Date type not supported: {0}
 errorParsingDate=Error parsing {1} from value: {0}. Check your @JsonbDateFormat has all time units for {1} type, \
   or consider using org.eclipse.yasson.YassonProperties#ZERO_TIME_PARSE_DEFAULTING.
-noDefaultConstructor=Can''t create instance of a class: {0}, No default constructor found.
+noDefaultConstructor=Cannot create instance of a class: {0}, No default constructor found.
 offsetDateTimeFromMillis=Parsing {0} from epoch millisecond, UTC zone offset will be used.
-timeToEpochMillisError=Cant convert {0} to/from epoch milliseconds.
+timeToEpochMillisError=Cannot convert {0} to/from epoch milliseconds.
 configPropertyInvalidType=JsonbConfig property [{0}] must be of type [{1}].
 conversionNotSupported=Conversion of type [{0}] to/from string value is not supported.
 endOfJsonStructure=End of JSON structure reached.
@@ -71,7 +74,7 @@ invalidPropertyNamingStrategy=Property naming strategy must be either: String na
 creatorParameterNotAnnotated=Argument has no JsonbProperty annotation for JsonbCreator {0}.
 unknownJsonProperty=Json property {0} can not be mapped to a class {1}.
 jsonbCreatorMissingProperty=JsonbCreator parameter {0} is missing in json document.
-zoneParseError=Can't parse zone from json value: {0}
+zoneParseError=Cannot parse zone from json value: {0}
 jsonbTransientWithOtherAnnotations=JsonbTransient annotation cannot be used with other jsonb annotations on the same property.
 nonParametrizedType=Type: {0} is not a parametrized type.
 propertyNameClash=Property {0} clashes with property {1} by read or write name in class {2}.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
@@ -68,7 +68,7 @@ public class UnmarshallingUnsupportedTypesTest {
             jsonb.fromJson(expected, ClassWithUnsupportedFields.class);
             fail("Should report an error");
         } catch (JsonbException e) {
-            assertTrue(e.getMessage().contains("Can't infer a type"));
+            assertTrue(e.getMessage().contains("Cannot infer a type"));
             assertTrue(e.getMessage().contains("customInterface"));
         }
     }


### PR DESCRIPTION
These are some cosmetic changes to the Yasson messages that are required by the tooling my translation team uses in IBM when we pull in Yasson to OpenLiberty.

I know it's a bit annoying to have to jump through hoops like this, but the benefit is that yasson-messages.properties will get translated into ~12 languages and I can contribute these translations back to Yasson when they come through.