### PR TITLE
Update tests to Junit 5.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,11 +521,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
+			    <groupId>org.junit.jupiter</groupId>
+			    <artifactId>junit-jupiter-api</artifactId>
+			    <version>5.5.2</version>
+			    <scope>test</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -552,8 +552,8 @@
             <artifactId>weld-se</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,12 @@
 			    <version>5.5.2</version>
 			    <scope>test</scope>
 			</dependency>
+			<dependency>
+			    <groupId>org.junit.jupiter</groupId>
+			    <artifactId>junit-jupiter-engine</artifactId>
+			    <version>5.5.2</version>
+			    <scope>test</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -554,6 +560,10 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/test/java/PackagelessClassTest.java
+++ b/src/test/java/PackagelessClassTest.java
@@ -39,5 +39,4 @@ public class PackagelessClassTest {
         assertEquals(packagelessModel.getIntValue(), 12);
         assertEquals(packagelessModel.getStringValue(), "Hello World!");
     }
-
 }

--- a/src/test/java/PackagelessClassTest.java
+++ b/src/test/java/PackagelessClassTest.java
@@ -10,12 +10,11 @@
  * Contributors:
  *     Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com) - initial implementation
  ******************************************************************************/
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the serialization/deserialization of a class that has no package.

--- a/src/test/java/PackagelessClassTest.java
+++ b/src/test/java/PackagelessClassTest.java
@@ -10,11 +10,10 @@
  * Contributors:
  *     Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com) - initial implementation
  ******************************************************************************/
+
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
+import static org.eclipse.yasson.Jsonbs.*;
 
 /**
  * Tests the serialization/deserialization of a class that has no package.
@@ -22,14 +21,13 @@ import javax.json.bind.JsonbBuilder;
  * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
  */
 public class PackagelessClassTest {
-    private Jsonb jsonb = JsonbBuilder.create();
 
     @Test
     public void testSerialization() throws Exception {
         PackagelessModel packagelessClass = new PackagelessModel(12, "Hello World!");
 
         String expected = "{\"intValue\":12,\"stringValue\":\"Hello World!\"}";
-        assertEquals(expected, jsonb.toJson(packagelessClass));
+        assertEquals(expected, defaultJsonb.toJson(packagelessClass));
     }
 
     @Test
@@ -37,7 +35,7 @@ public class PackagelessClassTest {
         PackagelessModel packagelessClass = new PackagelessModel(12, "Hello World!");
 
         String input = "{\"intValue\":12,\"stringValue\":\"Hello World!\"}";
-        PackagelessModel packagelessModel = jsonb.fromJson(input, PackagelessModel.class);
+        PackagelessModel packagelessModel = defaultJsonb.fromJson(input, PackagelessModel.class);
         assertEquals(packagelessModel.getIntValue(), 12);
         assertEquals(packagelessModel.getStringValue(), "Hello World!");
     }

--- a/src/test/java/org/eclipse/yasson/Assertions.java
+++ b/src/test/java/org/eclipse/yasson/Assertions.java
@@ -1,6 +1,6 @@
 package org.eclipse.yasson;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/src/test/java/org/eclipse/yasson/Assertions.java
+++ b/src/test/java/org/eclipse/yasson/Assertions.java
@@ -61,7 +61,5 @@ public class Assertions {
 				fail("Expected to get an exception of " + expectedType + " but instead was " + t.getClass());
 			}
 		}
-		
 	}
-
 }

--- a/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
+++ b/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
@@ -134,15 +134,15 @@ public class DefaultGetterInInterface {
         assertEquals(PojoWithDefaultImplementation.class.getMethod("getGetterI"), pojoTwoDefault);
 
         // assert serialized json is correct, including property name as specified by JsonbProperty annotations
-        this.assertJson(new Pojo(), "implementation");
-        this.assertJson(new PojoNoAnnotation(), "withGetterI");
-        this.assertJson(new PojoWithDefaultOnly(), "default");
-        this.assertJson(new PojoWithDefaultSuperImplementation(), "implementation");
-        this.assertJson(new PojoWithDefaultImplementation(), "defaultImplementation");
-        this.assertJson(new PojoGetterDefaultedTwice(), "defaultImplementation");
+        assertJson(new Pojo(), "implementation");
+        assertJson(new PojoNoAnnotation(), "withGetterI");
+        assertJson(new PojoWithDefaultOnly(), "default");
+        assertJson(new PojoWithDefaultSuperImplementation(), "implementation");
+        assertJson(new PojoWithDefaultImplementation(), "defaultImplementation");
+        assertJson(new PojoGetterDefaultedTwice(), "defaultImplementation");
     }
 
-    private void assertJson(WithGetterI pojo, String expected){
+    private static void assertJson(WithGetterI pojo, String expected){
         assertEquals(expected, pojo.getGetterI());
         assertEquals("{\"" + expected + "\":\"" + pojo.getGetterI() + "\"}", defaultJsonb.toJson(pojo));
     }

--- a/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
+++ b/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
@@ -14,11 +14,10 @@ package org.eclipse.yasson;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.internal.JsonbContext;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.spi.JsonProvider;
@@ -29,13 +28,6 @@ import java.lang.reflect.Method;
  * @author Maxence Laurent
  */
 public class DefaultGetterInInterface {
-
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
 
     public static interface Defaulted {
 
@@ -50,8 +42,8 @@ public class DefaultGetterInInterface {
     @Test
     public void testWithDefault() {
         PojoWithDefault pojo = new PojoWithDefault();
-        String result = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"getterA\":\"valueA\"}", result);
+        String result = defaultJsonb.toJson(pojo);
+        assertEquals("{\"getterA\":\"valueA\"}", result);
     }
 
     public static interface WithGetterI {
@@ -152,6 +144,6 @@ public class DefaultGetterInInterface {
 
     private void assertJson(WithGetterI pojo, String expected){
         assertEquals(expected, pojo.getGetterI());
-        assertEquals("{\"" + expected + "\":\"" + pojo.getGetterI() + "\"}", jsonb.toJson(pojo));
+        assertEquals("{\"" + expected + "\":\"" + pojo.getGetterI() + "\"}", defaultJsonb.toJson(pojo));
     }
 }

--- a/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
+++ b/src/test/java/org/eclipse/yasson/DefaultGetterInInterface.java
@@ -12,10 +12,10 @@
  ******************************************************************************/
 package org.eclipse.yasson;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.JsonbContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -23,8 +23,6 @@ import javax.json.bind.JsonbConfig;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.spi.JsonProvider;
 import java.lang.reflect.Method;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  *

--- a/src/test/java/org/eclipse/yasson/FieldAccessStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/FieldAccessStrategyTest.java
@@ -11,8 +11,8 @@
  * Roman Grigoriadi
  ******************************************************************************/package org.eclipse.yasson;
 
-import org.junit.Assert;
-import org.junit.Test;
+ import org.junit.jupiter.api.*;
+ import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -62,11 +62,11 @@ public class FieldAccessStrategyTest {
 
         String expected = "{\"strField\":\"pojo string\"}";
 
-        Assert.assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, jsonb.toJson(pojo));
         PrivateFields result = jsonb.fromJson(expected, PrivateFields.class);
-        Assert.assertEquals(false, result.getterCalled);
-        Assert.assertEquals(false, result.setterCalled);
-        Assert.assertEquals("pojo string", result.strField);
+        assertEquals(false, result.getterCalled);
+        assertEquals(false, result.setterCalled);
+        assertEquals("pojo string", result.strField);
     }
 
 
@@ -79,9 +79,9 @@ public class FieldAccessStrategyTest {
 
         String expected = "{}";
 
-        Assert.assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, jsonb.toJson(pojo));
         PublicFields result = jsonb.fromJson("{\"strField\":\"pojo string\"}", PublicFields.class);
-        Assert.assertEquals(null, result.strField);
+        assertEquals(null, result.strField);
     }
 
     /**
@@ -96,13 +96,13 @@ public class FieldAccessStrategyTest {
         simpleContainer.setStringInstance("Test String");
         simpleContainer.setIntegerInstance(10);
         simpleContainer.setFloatInstance(10.0f);
-        Assert.assertEquals(json, jsonb.toJson(simpleContainer));
+        assertEquals(json, jsonb.toJson(simpleContainer));
 
 
         SimpleContainer result = jsonb.fromJson("{ \"stringInstance\" : \"Test String\", \"floatInstance\" : 1.0, \"integerInstance\" : 1 }", SimpleContainer.class);
-        Assert.assertEquals("Test String", result.stringInstance);
-        Assert.assertNull(result.integerInstance);
-        Assert.assertNull(result.floatInstance);
+        assertEquals("Test String", result.stringInstance);
+        assertNull(result.integerInstance);
+        assertNull(result.floatInstance);
     }
 
     public class CustomVisibilityStrategy implements PropertyVisibilityStrategy {

--- a/src/test/java/org/eclipse/yasson/JavaxNamingExcludedTest.java
+++ b/src/test/java/org/eclipse/yasson/JavaxNamingExcludedTest.java
@@ -9,16 +9,15 @@
  ******************************************************************************/
 package org.eclipse.yasson;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.cdi.NonCdiAdapter;
 import org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Requires --limit-modules java.base,java.logging,java.sql (to exclude java.naming) to work.
@@ -30,7 +29,7 @@ public class JavaxNamingExcludedTest {
     public void testNoJavaxNamingModule() {
         try {
             Class.forName(JsonbComponentInstanceCreatorFactory.INITIAL_CONTEXT_CLASS);
-            Assert.fail("Class [" + JsonbComponentInstanceCreatorFactory.INITIAL_CONTEXT_CLASS
+            fail("Class [" + JsonbComponentInstanceCreatorFactory.INITIAL_CONTEXT_CLASS
                     + "] should not be available for this test.");
         } catch (ClassNotFoundException e) {
             //OK, java.naming is not observable

--- a/src/test/java/org/eclipse/yasson/JavaxNamingExcludedTest.java
+++ b/src/test/java/org/eclipse/yasson/JavaxNamingExcludedTest.java
@@ -11,12 +11,11 @@ package org.eclipse.yasson;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.internal.cdi.NonCdiAdapter;
 import org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
 
 /**
@@ -35,10 +34,8 @@ public class JavaxNamingExcludedTest {
             //OK, java.naming is not observable
         }
 
-        Jsonb jsonb = JsonbBuilder.create();
-        final String result = jsonb.toJson(new AdaptedPojo());
+        final String result = defaultJsonb.toJson(new AdaptedPojo());
         assertEquals("{\"adaptedValue1\":1111,\"adaptedValue2\":1001,\"adaptedValue3\":1010}", result);
-
     }
 
     public static final class AdaptedPojo {
@@ -50,6 +47,5 @@ public class JavaxNamingExcludedTest {
 
         @JsonbTypeAdapter(NonCdiAdapter.class)
         public String adaptedValue3 = "1010";
-
     }
 }

--- a/src/test/java/org/eclipse/yasson/Jsonbs.java
+++ b/src/test/java/org/eclipse/yasson/Jsonbs.java
@@ -1,0 +1,9 @@
+package org.eclipse.yasson;
+
+import javax.json.bind.*;
+import org.eclipse.yasson.internal.*;
+
+public class Jsonbs {
+	public static final Jsonb defaultJsonb = JsonbBuilder.create();
+	public static final Jsonb bindingJsonb = new JsonBindingBuilder().build();
+}

--- a/src/test/java/org/eclipse/yasson/Jsonbs.java
+++ b/src/test/java/org/eclipse/yasson/Jsonbs.java
@@ -6,4 +6,8 @@ import org.eclipse.yasson.internal.*;
 public class Jsonbs {
 	public static final Jsonb defaultJsonb = JsonbBuilder.create();
 	public static final Jsonb bindingJsonb = new JsonBindingBuilder().build();
+	public static final Jsonb formattingJsonb = JsonbBuilder.create(new JsonbConfig().withFormatting(Boolean.TRUE));
+	public static final Jsonb nullableJsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
+    public static final YassonJsonb yassonJsonb = (YassonJsonb) JsonbBuilder.create();
+	public static final YassonJsonb bindingYassonJsonb = (YassonJsonb) new JsonBindingProvider().create().build();
 }

--- a/src/test/java/org/eclipse/yasson/SimpleTest.java
+++ b/src/test/java/org/eclipse/yasson/SimpleTest.java
@@ -12,13 +12,13 @@
  ******************************************************************************/
 package org.eclipse.yasson;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/SimpleTest.java
+++ b/src/test/java/org/eclipse/yasson/SimpleTest.java
@@ -14,17 +14,29 @@ package org.eclipse.yasson;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import org.eclipse.yasson.internal.JsonBindingBuilder;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
+import static org.eclipse.yasson.Jsonbs.*;
 
 /**
  * @author Roman Grigoriadi
  */
 public class SimpleTest {
 
+    @Test
+    public void testSimpleSerialize() {
+        final StringWrapper wrapper = new StringWrapper();
+        wrapper.setValue("abc");
+        bindingJsonb.toJson(wrapper);
+        final String val = bindingJsonb.toJson(wrapper);
+        assertEquals("{\"value\":\"abc\"}", val);
+    }
+
+    @Test
+    public void testSimpleDeserializer() {
+        final StringWrapper stringWrapper = defaultJsonb.fromJson("{\"value\":\"abc\"}", StringWrapper.class);
+        assertEquals("abc", stringWrapper.getValue());
+    }
+    
+    
     public static class StringWrapper {
         public String value;
 
@@ -35,24 +47,5 @@ public class SimpleTest {
         public void setValue(String value) {
             this.value = value;
         }
-    }
-
-
-    Jsonb jsonb = JsonbBuilder.create();
-
-    @Test
-    public void testSimpleSerialize() {
-        Jsonb jsonb = (new JsonBindingBuilder()).build();
-        final StringWrapper wrapper = new StringWrapper();
-        wrapper.setValue("abc");
-        jsonb.toJson(wrapper);
-        final String val = jsonb.toJson(wrapper);
-        assertEquals("{\"value\":\"abc\"}", val);
-    }
-
-    @Test
-    public void testSimpleDeserializer() {
-        final StringWrapper stringWrapper = jsonb.fromJson("{\"value\":\"abc\"}", StringWrapper.class);
-        assertEquals("abc", stringWrapper.getValue());
     }
 }

--- a/src/test/java/org/eclipse/yasson/YassonPropertiesTest.java
+++ b/src/test/java/org/eclipse/yasson/YassonPropertiesTest.java
@@ -1,12 +1,12 @@
 package org.eclipse.yasson;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.eclipse.yasson.YassonProperties.FAIL_ON_UNKNOWN_PROPERTIES;
 import static org.eclipse.yasson.YassonProperties.NULL_ROOT_SERIALIZER;
 import static org.eclipse.yasson.YassonProperties.USER_TYPE_MAPPING;
 import static org.eclipse.yasson.YassonProperties.ZERO_TIME_PARSE_DEFAULTING;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests that the names of configuration fields in {@link YassonProperties} do not change.

--- a/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
@@ -434,11 +434,11 @@ public class AdaptersTest {
 
         Jsonb jsonb = JsonbBuilder.create();
         String json = jsonb.toJson(author);
-        Assert.assertEquals("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", json);
+        assertEquals("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", json);
 
         Author result = jsonb.fromJson("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", Author.class);
-        Assert.assertEquals("\"J\"", result.getFirstName());
-        Assert.assertEquals("Connor", result.getLastName());
+        assertEquals("\"J\"", result.getFirstName());
+        assertEquals("Connor", result.getLastName());
     }
 
     @Test
@@ -451,10 +451,10 @@ public class AdaptersTest {
         }.getType();
         String json = jsonb.toJson(wrapper, type);
 
-        Assert.assertEquals("{\"value\":null}", json);
+        assertEquals("{\"value\":null}", json);
 
         ScalarValueWrapper<Number> result = jsonb.fromJson("{\"value\":null}", type);
-        Assert.assertNull(result.getValue());
+        assertNull(result.getValue());
     }
 
     @Test
@@ -466,11 +466,11 @@ public class AdaptersTest {
         pojo.setUuidIfcBased(uuid);
 
         String result = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"uuidClsBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\",\"uuidIfcBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\"}", result);
+        assertEquals("{\"uuidClsBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\",\"uuidIfcBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\"}", result);
 
         UUIDContainer uuidContainer = jsonb.fromJson(result, UUIDContainer.class);
-        Assert.assertEquals(uuid, uuidContainer.getUuidClsBased());
-        Assert.assertEquals(uuid, uuidContainer.getUuidIfcBased());
+        assertEquals(uuid, uuidContainer.getUuidClsBased());
+        assertEquals(uuid, uuidContainer.getUuidIfcBased());
     }
 
     @Test
@@ -479,10 +479,10 @@ public class AdaptersTest {
         SupertypeAdapterPojo pojo = new SupertypeAdapterPojo();
         pojo.setNumberInteger(10);
         pojo.setSerializableInteger(11);
-        Assert.assertEquals("{\"numberInteger\":\"11\",\"serializableInteger\":12}", jsonb.toJson(pojo));
+        assertEquals("{\"numberInteger\":\"11\",\"serializableInteger\":12}", jsonb.toJson(pojo));
         pojo = jsonb.fromJson("{\"numberInteger\":\"11\",\"serializableInteger\":12}", SupertypeAdapterPojo.class);
-        Assert.assertEquals(Integer.valueOf(10), pojo.getNumberInteger());
-        Assert.assertEquals(Integer.valueOf(11), pojo.getSerializableInteger());
+        assertEquals(Integer.valueOf(10), pojo.getNumberInteger());
+        assertEquals(Integer.valueOf(11), pojo.getSerializableInteger());
     }
     
     public static class PropertyTypeMismatch {
@@ -532,7 +532,7 @@ public class AdaptersTest {
         PropertyTypeMismatch obj = new PropertyTypeMismatch();
         String json = jsonb.toJson(obj);
         assertEquals("{\"error\":{\"message\":\"foo\",\"type\":\"java.lang.RuntimeException\"}}", json);
-        assertEquals("The user-defined ThrowableAdapter should have been called", 1, adapter.callCount);
+        assertEquals(1, adapter.callCount, "The user-defined ThrowableAdapter should have been called");
     }
     
     public static class InstantAdapter implements JsonbAdapter<Instant, String> {

--- a/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.adapters;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.AdaptedPojo;
@@ -26,7 +27,6 @@ import org.eclipse.yasson.adapters.model.Crate;
 import org.eclipse.yasson.adapters.model.GenericBox;
 import org.eclipse.yasson.adapters.model.IntegerListToStringAdapter;
 import org.eclipse.yasson.adapters.model.JsonObjectPojo;
-import org.eclipse.yasson.adapters.model.ReturnNullAdapter;
 import org.eclipse.yasson.adapters.model.SupertypeAdapterPojo;
 import org.eclipse.yasson.adapters.model.UUIDContainer;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
@@ -55,7 +55,7 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class AdaptersTest {
 
-    private Jsonb jsonb;
+    //private Jsonb jsonb;
 
     public static class NonGenericPojo {
         public String strValues;
@@ -83,7 +83,7 @@ public class AdaptersTest {
                     }
                 }
         };
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo pojo = new AdaptedPojo();
         Box box = new Box();
@@ -113,7 +113,7 @@ public class AdaptersTest {
                     }
                 }
         };
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo pojo = new AdaptedPojo();
         pojo.intField = 11;
@@ -128,7 +128,7 @@ public class AdaptersTest {
     public void testGenericAdapter() throws Exception {
         JsonbAdapter<?, ?>[] adapters = {new BoxToCrateCompatibleGenericsAdapter<Integer>() {
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<Integer> pojo = new AdaptedPojo<>();
         pojo.strField = "POJO_STRING";
@@ -158,7 +158,7 @@ public class AdaptersTest {
     @Test
     public void testPropagatedTypeArgs() throws Exception {
         JsonbAdapter<?, ?>[] adapters = {new BoxToCratePropagatedIntegerStringAdapter()};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<Integer> pojo = new AdaptedPojo<>();
         pojo.intBox = new GenericBox<>("INT_BOX_STR", 110);
@@ -188,9 +188,8 @@ public class AdaptersTest {
 
     @Test
     public void testStringToGenericCollectionAdapter() throws Exception {
-
         JsonbAdapter<?, ?>[] adapters = {new IntegerListToStringAdapter()};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<List<Integer>> pojo = new AdaptedPojo<>();
         pojo.tVar = Arrays.asList(11, 22, 33);
@@ -216,7 +215,7 @@ public class AdaptersTest {
     public void testAdaptObjectInCollection() throws Exception {
         JsonbAdapter<?, ?>[] adapters = {new BoxToCrateCompatibleGenericsAdapter<Integer>() {
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<Integer> pojo = new AdaptedPojo<>();
 
@@ -263,7 +262,7 @@ public class AdaptersTest {
             }
         }
         };
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         String json = "{\"strValues\":[11,22,33]}";
         final NonGenericPojo object = new NonGenericPojo();
@@ -276,7 +275,7 @@ public class AdaptersTest {
     @Test
     public void testMarshallGenericField() throws Exception {
         JsonbAdapter<?, ?>[] adapters = {new BoxToCratePropagatedIntegerStringAdapter()};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<Integer> adaptedPojo = new AdaptedPojo<>();
         adaptedPojo.tBox = new GenericBox<>("tGenBoxStrField", 22);
@@ -304,7 +303,7 @@ public class AdaptersTest {
                 return list;
             }
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<List<GenericBox<Double>>> intBoxPojo = new AdaptedPojo<>();
         List<GenericBox<Double>> intBoxList = new ArrayList<>();
@@ -332,7 +331,7 @@ public class AdaptersTest {
                 return new Box(crate.getCrateStrField(), crate.getCrateIntField());
             }
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         Box pojo = new Box("BOX_STR", 101);
         String marshalledJson = jsonb.toJson(pojo);
@@ -366,7 +365,7 @@ public class AdaptersTest {
                 return sb.toString();
             }
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<Integer> pojo = new AdaptedPojo<>();
         pojo.stringIntegerMap = new HashMap<>();
@@ -397,7 +396,7 @@ public class AdaptersTest {
                 return new Crate(next.getKey(), Integer.parseInt(next.getValue()));
             }
         }};
-        jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().setProperty(JsonbConfig.ADAPTERS, adapters));
 
         AdaptedPojo<String> pojo = new AdaptedPojo<>();
         pojo.tMap = new HashMap<>();
@@ -414,14 +413,13 @@ public class AdaptersTest {
 
     @Test
     public void testAdaptJsonObject() {
-        jsonb = JsonbBuilder.create();
         JsonObjectPojo pojo = new JsonObjectPojo();
         pojo.box = new Box("strFieldValue", 110);
 
-        String json = jsonb.toJson(pojo);
+        String json = defaultJsonb.toJson(pojo);
         assertEquals("{\"box\":{\"boxStrField\":\"strFieldValue\",\"boxIntegerField\":110}}", json);
 
-        JsonObjectPojo result = jsonb.fromJson(json, JsonObjectPojo.class);
+        JsonObjectPojo result = defaultJsonb.fromJson(json, JsonObjectPojo.class);
         assertEquals("strFieldValue", result.box.getBoxStrField());
         assertEquals(Integer.valueOf(110), result.box.getBoxIntegerField());
     }
@@ -432,55 +430,50 @@ public class AdaptersTest {
         author.setFirstName("John");
         author.setLastName("Connor");
 
-        Jsonb jsonb = JsonbBuilder.create();
-        String json = jsonb.toJson(author);
+        String json = defaultJsonb.toJson(author);
         assertEquals("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", json);
 
-        Author result = jsonb.fromJson("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", Author.class);
+        Author result = defaultJsonb.fromJson("{\"firstName\":\"J\",\"lastName\":\"Connor\"}", Author.class);
         assertEquals("\"J\"", result.getFirstName());
         assertEquals("Connor", result.getLastName());
     }
 
     @Test
     public void testAdapterReturningNull() {
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withAdapters(new ReturnNullAdapter()).withNullValues(true));
-
         ScalarValueWrapper<Number> wrapper = new ScalarValueWrapper<>();
         wrapper.setValue(10);
         Type type = new TestTypeToken<ScalarValueWrapper<Number>>() {
         }.getType();
-        String json = jsonb.toJson(wrapper, type);
+        String json = nullableJsonb.toJson(wrapper, type);
 
         assertEquals("{\"value\":null}", json);
 
-        ScalarValueWrapper<Number> result = jsonb.fromJson("{\"value\":null}", type);
+        ScalarValueWrapper<Number> result = nullableJsonb.fromJson("{\"value\":null}", type);
         assertNull(result.getValue());
     }
 
     @Test
     public void testAdaptUUID() {
-        jsonb = JsonbBuilder.create();
         UUIDContainer pojo = new UUIDContainer();
         UUID uuid = UUID.fromString("b329da91-0d96-44b6-b466-56c2458b2877");
         pojo.setUuidClsBased(uuid);
         pojo.setUuidIfcBased(uuid);
 
-        String result = jsonb.toJson(pojo);
+        String result = defaultJsonb.toJson(pojo);
         assertEquals("{\"uuidClsBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\",\"uuidIfcBased\":\"b329da91-0d96-44b6-b466-56c2458b2877\"}", result);
 
-        UUIDContainer uuidContainer = jsonb.fromJson(result, UUIDContainer.class);
+        UUIDContainer uuidContainer = defaultJsonb.fromJson(result, UUIDContainer.class);
         assertEquals(uuid, uuidContainer.getUuidClsBased());
         assertEquals(uuid, uuidContainer.getUuidIfcBased());
     }
 
     @Test
     public void testSupertypeAdapter() {
-        jsonb = JsonbBuilder.create();
         SupertypeAdapterPojo pojo = new SupertypeAdapterPojo();
         pojo.setNumberInteger(10);
         pojo.setSerializableInteger(11);
-        assertEquals("{\"numberInteger\":\"11\",\"serializableInteger\":12}", jsonb.toJson(pojo));
-        pojo = jsonb.fromJson("{\"numberInteger\":\"11\",\"serializableInteger\":12}", SupertypeAdapterPojo.class);
+        assertEquals("{\"numberInteger\":\"11\",\"serializableInteger\":12}", defaultJsonb.toJson(pojo));
+        pojo = defaultJsonb.fromJson("{\"numberInteger\":\"11\",\"serializableInteger\":12}", SupertypeAdapterPojo.class);
         assertEquals(Integer.valueOf(10), pojo.getNumberInteger());
         assertEquals(Integer.valueOf(11), pojo.getSerializableInteger());
     }
@@ -525,9 +518,7 @@ public class AdaptersTest {
     @Test
     public void testOptionalAdapter() {
         ThrowableAdapter adapter = new ThrowableAdapter();
-        jsonb = JsonbBuilder.newBuilder()
-                .withConfig(new JsonbConfig().withAdapters(adapter))
-                .build();
+        Jsonb jsonb = JsonbBuilder.newBuilder().withConfig(new JsonbConfig().withAdapters(adapter)).build();
         
         PropertyTypeMismatch obj = new PropertyTypeMismatch();
         String json = jsonb.toJson(obj);
@@ -561,7 +552,7 @@ public class AdaptersTest {
     public void testDifferentAdapters() {
         ThrowableAdapter throwableAdapter = new ThrowableAdapter();
         InstantAdapter instantAdapter = new InstantAdapter();
-        jsonb = JsonbBuilder.newBuilder()
+        Jsonb jsonb = JsonbBuilder.newBuilder()
                 .withConfig(new JsonbConfig().withAdapters(throwableAdapter, instantAdapter))
                 .build();
         
@@ -575,5 +566,4 @@ public class AdaptersTest {
                 afterJson);
         assertEquals(1, throwableAdapter.callCount);
     }
-    
 }

--- a/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
@@ -55,8 +55,6 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class AdaptersTest {
 
-    //private Jsonb jsonb;
-
     public static class NonGenericPojo {
         public String strValues;
         public Box box;
@@ -109,7 +107,7 @@ public class AdaptersTest {
 
                     @Override
                     public Integer adaptFromJson(String s) {
-                        return Integer.parseInt(s);
+                        return Integer.valueOf(s);
                     }
                 }
         };
@@ -152,7 +150,6 @@ public class AdaptersTest {
         assertEquals(22, result.tBox.getX());
         assertEquals("strBoxStr", result.strBox.getStrField());
         assertEquals("44", result.strBox.getX());
-
     }
 
     @Test

--- a/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
@@ -18,17 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
-import org.eclipse.yasson.adapters.model.AdaptedPojo;
-import org.eclipse.yasson.adapters.model.Author;
-import org.eclipse.yasson.adapters.model.Box;
-import org.eclipse.yasson.adapters.model.BoxToCrateCompatibleGenericsAdapter;
-import org.eclipse.yasson.adapters.model.BoxToCratePropagatedIntegerStringAdapter;
-import org.eclipse.yasson.adapters.model.Crate;
-import org.eclipse.yasson.adapters.model.GenericBox;
-import org.eclipse.yasson.adapters.model.IntegerListToStringAdapter;
-import org.eclipse.yasson.adapters.model.JsonObjectPojo;
-import org.eclipse.yasson.adapters.model.SupertypeAdapterPojo;
-import org.eclipse.yasson.adapters.model.UUIDContainer;
+import org.eclipse.yasson.adapters.model.*;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 
 import javax.json.bind.Jsonb;
@@ -437,15 +427,17 @@ public class AdaptersTest {
 
     @Test
     public void testAdapterReturningNull() {
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withAdapters(new ReturnNullAdapter()).withNullValues(true));
+
         ScalarValueWrapper<Number> wrapper = new ScalarValueWrapper<>();
         wrapper.setValue(10);
         Type type = new TestTypeToken<ScalarValueWrapper<Number>>() {
         }.getType();
-        String json = nullableJsonb.toJson(wrapper, type);
+        String json = jsonb.toJson(wrapper, type);
 
         assertEquals("{\"value\":null}", json);
 
-        ScalarValueWrapper<Number> result = nullableJsonb.fromJson("{\"value\":null}", type);
+        ScalarValueWrapper<Number> result = jsonb.fromJson("{\"value\":null}", type);
         assertNull(result.getValue());
     }
 

--- a/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/AdaptersTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.yasson.adapters;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.AdaptedPojo;
@@ -28,8 +30,6 @@ import org.eclipse.yasson.adapters.model.ReturnNullAdapter;
 import org.eclipse.yasson.adapters.model.SupertypeAdapterPojo;
 import org.eclipse.yasson.adapters.model.UUIDContainer;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -47,7 +47,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Collections.unmodifiableMap;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests adapters to behave correctly.

--- a/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
@@ -34,7 +34,7 @@ public class JsonbTypeAdapterTest {
         @Override
         public Box adaptFromJson(String obj) throws Exception {
             String[] strings = obj.split(":");
-            return new Box(strings[0], Integer.parseInt(strings[1]));
+            return new Box(strings[0], Integer.valueOf(strings[1]));
         }
 
         @Override
@@ -62,7 +62,6 @@ public class JsonbTypeAdapterTest {
 
     @Test
     public void testIncompatibleAdapter() throws Exception {
-
         IncompatibleAdapterPojo incompatibleAdapterFieldPojo = new IncompatibleAdapterPojo();
         incompatibleAdapterFieldPojo.str = "STR";
         try {
@@ -72,7 +71,6 @@ public class JsonbTypeAdapterTest {
             assertTrue(e.getMessage().startsWith("Adapter of runtime type class"));
             assertTrue(e.getMessage().contains("does not match property type "));
         }
-
     }
 
     @Test
@@ -89,7 +87,6 @@ public class JsonbTypeAdapterTest {
 
     @Test
     public void testAnnotatedTbox() throws Exception {
-
         AnnotatedPojo pojo = new AnnotatedPojo();
         pojo.box = new Box("STR", 101);
         String marshalledJson = defaultJsonb.toJson(pojo);
@@ -124,5 +121,4 @@ public class JsonbTypeAdapterTest {
         assertEquals("STR", result.getBoxStrField());
         assertEquals(Integer.valueOf(101), result.getBoxIntegerField());
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
@@ -13,18 +13,17 @@
 
 package org.eclipse.yasson.adapters;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.*;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 import javax.json.bind.adapter.JsonbAdapter;
 import javax.json.bind.annotation.JsonbTypeAdapter;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
@@ -15,12 +15,11 @@ package org.eclipse.yasson.adapters;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.*;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 import javax.json.bind.adapter.JsonbAdapter;
 import javax.json.bind.annotation.JsonbTypeAdapter;
@@ -29,8 +28,6 @@ import javax.json.bind.annotation.JsonbTypeAdapter;
  * @author Roman Grigoriadi
  */
 public class JsonbTypeAdapterTest {
-
-    private Jsonb jsonb;
 
     public static class BoxToStringAdapter implements JsonbAdapter<Box, String> {
 
@@ -63,18 +60,13 @@ public class JsonbTypeAdapterTest {
         public GenericBox<X> xBox;
     }
 
-    @Before
-    public void setUp() throws Exception {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testIncompatibleAdapter() throws Exception {
 
         IncompatibleAdapterPojo incompatibleAdapterFieldPojo = new IncompatibleAdapterPojo();
         incompatibleAdapterFieldPojo.str = "STR";
         try {
-            jsonb.toJson(incompatibleAdapterFieldPojo);
+            defaultJsonb.toJson(incompatibleAdapterFieldPojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("Adapter of runtime type class"));
@@ -87,10 +79,10 @@ public class JsonbTypeAdapterTest {
     public void testGenericFieldsMatch() {
         AnnotatedPojo<Integer, String> annotatedPojo = new AnnotatedPojo<>();
         annotatedPojo.tBox = new GenericBox<>("T_BOX", 110);
-        String marshalledJson = jsonb.toJson(annotatedPojo, new TestTypeToken<AnnotatedPojo<Integer, String>>(){}.getType());
+        String marshalledJson = defaultJsonb.toJson(annotatedPojo, new TestTypeToken<AnnotatedPojo<Integer, String>>(){}.getType());
         assertEquals("{\"tBox\":{\"adaptedT\":{\"x\":[\"110\"]},\"crateStrField\":\"T_BOX\"}}", marshalledJson);
 
-        AnnotatedPojo<Integer,String> result = jsonb.fromJson("{\"tBox\":{\"crateStrField\":\"T_BOX\",\"adaptedT\":{\"x\":[\"110\"]}}}", new TestTypeToken<AnnotatedPojo<Integer,String>>(){}.getType());
+        AnnotatedPojo<Integer,String> result = defaultJsonb.fromJson("{\"tBox\":{\"crateStrField\":\"T_BOX\",\"adaptedT\":{\"x\":[\"110\"]}}}", new TestTypeToken<AnnotatedPojo<Integer,String>>(){}.getType());
         assertEquals("T_BOX", result.tBox.getStrField());
         assertEquals(Integer.valueOf(110), result.tBox.getX());
     }
@@ -100,10 +92,10 @@ public class JsonbTypeAdapterTest {
 
         AnnotatedPojo pojo = new AnnotatedPojo();
         pojo.box = new Box("STR", 101);
-        String marshalledJson = jsonb.toJson(pojo);
+        String marshalledJson = defaultJsonb.toJson(pojo);
         assertEquals("{\"box\":\"STR:101\"}", marshalledJson);
 
-        AnnotatedPojo<?, ?> result = jsonb.fromJson("{\"box\":\"STR:110\"}", AnnotatedPojo.class);
+        AnnotatedPojo<?, ?> result = defaultJsonb.fromJson("{\"box\":\"STR:110\"}", AnnotatedPojo.class);
         assertEquals("STR", result.box.getBoxStrField());
         assertEquals(Integer.valueOf(110), result.box.getBoxIntegerField());
     }
@@ -111,10 +103,10 @@ public class JsonbTypeAdapterTest {
     @Test
     public void testBoxWithTypeAdapter() {
         BoxWithAdapter boxWithAdapter = new BoxWithAdapter("STR", 101);
-        String marshalledJson = jsonb.toJson(boxWithAdapter);
+        String marshalledJson = defaultJsonb.toJson(boxWithAdapter);
         assertEquals("{\"boxInteger\":101,\"boxStr\":\"STR\"}", marshalledJson);
 
-        BoxWithAdapter result = jsonb.fromJson("{\"boxInteger\":101,\"boxStr\":\"STR\"}", BoxWithAdapter.class);
+        BoxWithAdapter result = defaultJsonb.fromJson("{\"boxInteger\":101,\"boxStr\":\"STR\"}", BoxWithAdapter.class);
         assertEquals("STR", result.getBoxStrField());
         assertEquals(Integer.valueOf(101), result.getBoxIntegerField());
     }
@@ -122,13 +114,13 @@ public class JsonbTypeAdapterTest {
     @Test
     public void testBoxWithTypeSerializer() {
         BoxWithSerializer boxWithSerializer = new BoxWithSerializer("STR", 101);
-        String marshalledJson = jsonb.toJson(boxWithSerializer);
+        String marshalledJson = defaultJsonb.toJson(boxWithSerializer);
         assertEquals("{\"boxInteger\":101,\"boxStr\":\"STR\"}", marshalledJson);
     }
 
     @Test
     public void testBoxWithTypeDeserializer() {
-        BoxWithDeserializer result = jsonb.fromJson("{\"boxInteger\":101,\"boxStr\":\"STR\"}", BoxWithDeserializer.class);
+        BoxWithDeserializer result = defaultJsonb.fromJson("{\"boxInteger\":101,\"boxStr\":\"STR\"}", BoxWithDeserializer.class);
         assertEquals("STR", result.getBoxStrField());
         assertEquals(Integer.valueOf(101), result.getBoxIntegerField());
     }

--- a/src/test/java/org/eclipse/yasson/customization/AnnotationInheritanceTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/AnnotationInheritanceTest.java
@@ -15,11 +15,9 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.InheritedAnnotationsPojo;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 /**
  * @author Roman Grigoriadi
@@ -30,10 +28,9 @@ public class AnnotationInheritanceTest {
     public void testAnnotationInheritance() {
         InheritedAnnotationsPojo pojo = new InheritedAnnotationsPojo();
         String expectedJson = "{}";
-        final Jsonb jsonb = JsonbBuilder.create();
-        assertEquals(expectedJson, jsonb.toJson(pojo));
+        assertEquals(expectedJson, defaultJsonb.toJson(pojo));
 
-        InheritedAnnotationsPojo result = jsonb.fromJson("{\"renamedProperty\":\"abc\"}", InheritedAnnotationsPojo.class);
+        InheritedAnnotationsPojo result = defaultJsonb.fromJson("{\"renamedProperty\":\"abc\"}", InheritedAnnotationsPojo.class);
         assertEquals("abc", result.property);
     }
 }

--- a/src/test/java/org/eclipse/yasson/customization/AnnotationInheritanceTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/AnnotationInheritanceTest.java
@@ -13,13 +13,13 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.InheritedAnnotationsPojo;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/customization/EncodingTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/EncodingTest.java
@@ -52,28 +52,34 @@ public class EncodingTest {
 
     @Test
     public void testCP1250Encoding() throws UnsupportedEncodingException {
-        testMarshaller(CZECH, "cp1250");
-        testUnmarshaller(CZECH, "cp1250");
+    	String encoding = "cp1250";
+    	Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withEncoding(encoding));
+    	
+        testMarshaller(CZECH, jsonb, encoding);
+        testUnmarshaller(CZECH, jsonb, encoding);
     }
 
     @Test
     public void testUTF8Encoding() throws UnsupportedEncodingException {
-        testMarshaller(CZECH, "UTF-8");
-        testUnmarshaller(CZECH, "UTF-8");
-        testMarshaller(RUSSIAN, "UTF-8");
-        testUnmarshaller(RUSSIAN, "UTF-8");
+    	String encoding = "UTF-8";
+    	Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withEncoding(encoding));
+    	
+        testMarshaller(CZECH, jsonb, encoding);
+        testUnmarshaller(CZECH, jsonb, encoding);
+        testMarshaller(RUSSIAN, jsonb, encoding);
+        testUnmarshaller(RUSSIAN, jsonb, encoding);
     }
 
     @Test
     public void testcp1251Encoding() throws UnsupportedEncodingException {
-        testMarshaller(RUSSIAN, "cp1251");
-        testUnmarshaller(RUSSIAN, "cp1251");
+    	String encoding = "cp1251";
+    	Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withEncoding(encoding));
+    	
+        testMarshaller(RUSSIAN, jsonb, encoding);
+        testUnmarshaller(RUSSIAN, jsonb, encoding);
     }
 
-    private void testMarshaller(String[] input, String encoding) throws UnsupportedEncodingException {
-        JsonbConfig config = new JsonbConfig().withEncoding(encoding);
-        final Jsonb jsonb = JsonbBuilder.create(config);
-
+    private static void testMarshaller(String[] input, Jsonb jsonb, String encoding) throws UnsupportedEncodingException {
         List<String> strings = Arrays.asList(input);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         jsonb.toJson(strings, baos);
@@ -82,10 +88,7 @@ public class EncodingTest {
         assertEquals(diacriticsToJsonArray(input), marshallerResult);
     }
 
-    private void testUnmarshaller(String[] input, String encoding) throws UnsupportedEncodingException {
-        JsonbConfig config = new JsonbConfig().withEncoding(encoding);
-        final Jsonb jsonb = JsonbBuilder.create(config);
-
+    private static void testUnmarshaller(String[] input, Jsonb jsonb, String encoding) throws UnsupportedEncodingException {
         String json = diacriticsToJsonArray(input);
         logger.finest("JSON for unmarshaller: "+json);
         InputStream bis = new ByteArrayInputStream(json.getBytes(encoding));
@@ -93,7 +96,7 @@ public class EncodingTest {
         assertArrayEquals(input, result.toArray(new String[result.size()]));
     }
 
-    private String diacriticsToJsonArray(String[] diacritics) {
+    private static String diacriticsToJsonArray(String[] diacritics) {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         for (String str : diacritics) {

--- a/src/test/java/org/eclipse/yasson/customization/EncodingTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/EncodingTest.java
@@ -13,8 +13,10 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -28,9 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.logging.Logger;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests encoding to JSONP propagation

--- a/src/test/java/org/eclipse/yasson/customization/ImplementationClassTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/ImplementationClassTest.java
@@ -12,10 +12,12 @@
  ******************************************************************************/
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.Animal;
 import org.eclipse.yasson.customization.model.Dog;
 import org.eclipse.yasson.customization.model.ImplementationClassPojo;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -23,8 +25,6 @@ import javax.json.bind.JsonbConfig;
 import java.util.HashMap;
 
 import static org.eclipse.yasson.YassonProperties.USER_TYPE_MAPPING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ImplementationClassTest {
 

--- a/src/test/java/org/eclipse/yasson/customization/ImplementationClassTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/ImplementationClassTest.java
@@ -14,6 +14,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.Animal;
 import org.eclipse.yasson.customization.model.Dog;
@@ -28,18 +29,16 @@ import static org.eclipse.yasson.YassonProperties.USER_TYPE_MAPPING;
 
 public class ImplementationClassTest {
 
-    private final Jsonb jsonb = JsonbBuilder.create();
-
     @Test
     public void testAnnotatedImplementation() {
         ImplementationClassPojo pojo = new ImplementationClassPojo();
         Animal dog = new Dog("Bulldog");
         pojo.setAnimal(dog);
         String expected = "{\"animal\":{\"dogProperty\":\"Bulldog\"}}";
-        String json = jsonb.toJson(pojo);
+        String json = defaultJsonb.toJson(pojo);
 
         assertEquals(expected, json);
-        ImplementationClassPojo result = jsonb.fromJson(expected, ImplementationClassPojo.class);
+        ImplementationClassPojo result = defaultJsonb.fromJson(expected, ImplementationClassPojo.class);
         assertTrue(result.getAnimal() instanceof Dog);
         assertEquals("Bulldog", ((Dog)result.getAnimal()).getDogProperty());
     }

--- a/src/test/java/org/eclipse/yasson/customization/InterfaceAnnotationsTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/InterfaceAnnotationsTest.java
@@ -13,14 +13,14 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.InterfacedPojoB;
 import org.eclipse.yasson.customization.model.InterfacedPojoImpl;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/customization/InterfaceAnnotationsTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/InterfaceAnnotationsTest.java
@@ -15,12 +15,10 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.InterfacedPojoB;
 import org.eclipse.yasson.customization.model.InterfacedPojoImpl;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 /**
  * @author Roman Grigoriadi
@@ -33,10 +31,7 @@ public class InterfaceAnnotationsTest {
         pojo.setPropertyA("AA");
         pojo.setPropertyB("BB");
 
-        final Jsonb jsonb = JsonbBuilder.create();
         final String json = "{\"propA\":\"AA\",\"propB\":\"BB\"}";
-        assertEquals(json, jsonb.toJson(pojo));
+        assertEquals(json, defaultJsonb.toJson(pojo));
     }
-
-
 }

--- a/src/test/java/org/eclipse/yasson/customization/JsonbCreatorTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbCreatorTest.java
@@ -15,11 +15,10 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.*;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbDateFormat;
@@ -37,8 +36,7 @@ public class JsonbCreatorTest {
     @Test
     public void testRootConstructor() {
         String json = "{\"str1\":\"abc\",\"str2\":\"def\",\"bigDec\":25}";
-        final Jsonb jsonb = JsonbBuilder.create();
-        CreatorConstructorPojo pojo = jsonb.fromJson(json, CreatorConstructorPojo.class);
+        CreatorConstructorPojo pojo = defaultJsonb.fromJson(json, CreatorConstructorPojo.class);
         assertEquals("abc", pojo.str1);
         assertEquals("def", pojo.str2);
         assertEquals(new BigDecimal("25"), pojo.bigDec);
@@ -47,8 +45,7 @@ public class JsonbCreatorTest {
     @Test
     public void testRootFactoryMethod() {
         String json = "{\"par1\":\"abc\",\"par2\":\"def\",\"bigDec\":25}";
-        final Jsonb jsonb = JsonbBuilder.create();
-        CreatorFactoryMethodPojo pojo = jsonb.fromJson(json, CreatorFactoryMethodPojo.class);
+        CreatorFactoryMethodPojo pojo = defaultJsonb.fromJson(json, CreatorFactoryMethodPojo.class);
         assertEquals("abc", pojo.str1);
         assertEquals("def", pojo.str2);
         assertEquals(new BigDecimal("25"), pojo.bigDec);
@@ -57,8 +54,7 @@ public class JsonbCreatorTest {
     @Test
     public void testRootCreatorWithInnerCreator() {
         String json = "{\"str1\":\"abc\",\"str2\":\"def\",\"bigDec\":25, \"innerFactoryCreator\":{\"par1\":\"inn1\",\"par2\":\"inn2\",\"bigDec\":11}}";
-        final Jsonb jsonb = JsonbBuilder.create();
-        CreatorConstructorPojo pojo = jsonb.fromJson(json, CreatorConstructorPojo.class);
+        CreatorConstructorPojo pojo = defaultJsonb.fromJson(json, CreatorConstructorPojo.class);
         assertEquals("abc", pojo.str1);
         assertEquals("def", pojo.str2);
         assertEquals(new BigDecimal("25"), pojo.bigDec);
@@ -71,7 +67,7 @@ public class JsonbCreatorTest {
     @Test
     public void testIncompatibleFactoryMethodReturnType() {
         try {
-            JsonbBuilder.create().fromJson("{\"s1\":\"abc\"}", CreatorIncompatibleTypePojo.class);
+        	defaultJsonb.fromJson("{\"s1\":\"abc\"}", CreatorIncompatibleTypePojo.class);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("Return type of creator"));
@@ -81,75 +77,73 @@ public class JsonbCreatorTest {
     @Test
     public void testMultipleCreatorsError() {
         try {
-            JsonbBuilder.create().fromJson("{\"s1\":\"abc\"}", CreatorMultipleDeclarationErrorPojo.class);
+        	defaultJsonb.fromJson("{\"s1\":\"abc\"}", CreatorMultipleDeclarationErrorPojo.class);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("More than one @JsonbCreator"));
         }
     }
 
-    @Test(expected = JsonbException.class)
+    @Test
     public void testCreatorWithoutJsonbParameters1() {
         //arg2 is missing in json document
-        JsonbBuilder.create().fromJson("{\"arg0\":\"abc\", \"s2\":\"def\"}", CreatorWithoutJsonbProperty1.class);
+    	assertThrows(JsonbException.class, () -> defaultJsonb.fromJson("{\"arg0\":\"abc\", \"s2\":\"def\"}", CreatorWithoutJsonbProperty1.class));
     }
 
     @Test
     public void testCreatorWithoutJavabeanProperty() {
-        final CreatorWithoutJavabeanProperty result = JsonbBuilder.create().fromJson("{\"s1\":\"abc\", \"s2\":\"def\"}", CreatorWithoutJavabeanProperty.class);
-        Assert.assertEquals("abcdef", result.getStrField());
+        final CreatorWithoutJavabeanProperty result = defaultJsonb.fromJson("{\"s1\":\"abc\", \"s2\":\"def\"}", CreatorWithoutJavabeanProperty.class);
+        assertEquals("abcdef", result.getStrField());
 
     }
 
-    @Test(expected = JsonbException.class)
+    @Test
     public void testPackagePrivateCreator() {
-        final CreatorPackagePrivateConstructor result = JsonbBuilder.create().fromJson(
-                "{\"strVal\":\"abc\", \"intVal\":5}", CreatorPackagePrivateConstructor.class);
+    	assertThrows(JsonbException.class, () -> defaultJsonb.fromJson("{\"strVal\":\"abc\", \"intVal\":5}", CreatorPackagePrivateConstructor.class));
     }
 
     @Test
     public void testLocalizedConstructor() {
         String json = "{\"localDate\":\"05-09-2017\"}";
-        DateConstructor result = JsonbBuilder.create().fromJson(json, DateConstructor.class);
-        Assert.assertEquals(LocalDate.of(2017, 9, 5), result.localDate);
+        DateConstructor result = defaultJsonb.fromJson(json, DateConstructor.class);
+        assertEquals(LocalDate.of(2017, 9, 5), result.localDate);
     }
 
     @Test
     public void testLocalizedConstructorMergedWithProperty() {
         String json = "{\"localDate\":\"05-09-2017\"}";
-        DateConstructorMergedWithProperty result = JsonbBuilder.create().fromJson(json, DateConstructorMergedWithProperty.class);
-        Assert.assertEquals(LocalDate.of(2017, 9, 5), result.localDate);
+        DateConstructorMergedWithProperty result = defaultJsonb.fromJson(json, DateConstructorMergedWithProperty.class);
+        assertEquals(LocalDate.of(2017, 9, 5), result.localDate);
     }
 
     @Test
     public void testLocalizedFactoryParameter() {
         String json = "{\"number\":\"10.000\"}";
-        FactoryNumberParam result = JsonbBuilder.create().fromJson(json, FactoryNumberParam.class);
-        Assert.assertEquals(BigDecimal.TEN, result.number);
+        FactoryNumberParam result = defaultJsonb.fromJson(json, FactoryNumberParam.class);
+        assertEquals(BigDecimal.TEN, result.number);
     }
 
     @Test
     public void testLocalizedFactoryParameterMergedWithProperty() {
         String json = "{\"number\":\"10.000\"}";
-        FactoryNumberParamMergedWithProperty result = JsonbBuilder.create().fromJson(json, FactoryNumberParamMergedWithProperty.class);
-        Assert.assertEquals(BigDecimal.TEN, result.number);
+        FactoryNumberParamMergedWithProperty result = defaultJsonb.fromJson(json, FactoryNumberParamMergedWithProperty.class);
+        assertEquals(BigDecimal.TEN, result.number);
     }
 
     @Test
     public void testCorrectCreatorParameterNames() {
         String json = "{\"string\":\"someText\", \"someParam\":null }";
-        ParameterNameTester result = JsonbBuilder.create().fromJson(json, ParameterNameTester.class);
-        Assert.assertEquals("someText", result.name);
-        Assert.assertNull(result.secondParam);
+        ParameterNameTester result = defaultJsonb.fromJson(json, ParameterNameTester.class);
+        assertEquals("someText", result.name);
+        assertNull(result.secondParam);
     }
 
     @Test
     public void testGenericCreatorParameter() throws Exception {
         final String json = "{\"persons\": [{\"name\": \"name1\"}]}";
-        Jsonb jsonb = JsonbBuilder.create();
-        Persons persons = jsonb.fromJson(json, Persons.class);
-        Assert.assertEquals(1, persons.hiddenPersons.size());
-        Assert.assertEquals("name1", persons.hiddenPersons.iterator().next().getName());
+        Persons persons = defaultJsonb.fromJson(json, Persons.class);
+        assertEquals(1, persons.hiddenPersons.size());
+        assertEquals("name1", persons.hiddenPersons.iterator().next().getName());
     }
 
     public static final class Persons {

--- a/src/test/java/org/eclipse/yasson/customization/JsonbCreatorTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbCreatorTest.java
@@ -13,9 +13,10 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.*;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -27,8 +28,6 @@ import javax.json.bind.annotation.JsonbProperty;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/customization/JsonbDateFormatterTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbDateFormatterTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.DateFormatPojo;
 import org.eclipse.yasson.customization.model.DateFormatPojoWithClassLevelFormatter;
@@ -39,8 +40,6 @@ import static org.eclipse.yasson.YassonProperties.ZERO_TIME_PARSE_DEFAULTING;
  */
 public class JsonbDateFormatterTest {
 
-    private final Jsonb jsonb = JsonbBuilder.create();
-
     @Test
     public void testCustomDateFormatSerialization() {
         final Calendar timeCalendar = new Calendar.Builder()
@@ -61,7 +60,7 @@ public class JsonbDateFormatterTest {
 
         String expectedJson = "{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"plainDateField\":\"2017-03-03T11:11:10Z[UTC]\",\"setterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"setterFormattedDateField\":\"2017-03-03T11:11:10Z[UTC]\"}";
 
-        assertEquals(expectedJson, jsonb.toJson(dateFormatPojo));
+        assertEquals(expectedJson, defaultJsonb.toJson(dateFormatPojo));
     }
 
     @Test
@@ -72,7 +71,7 @@ public class JsonbDateFormatterTest {
                 .setTimeZone(TimeZone.getTimeZone("UTC"))
                 .build();
 
-        DateFormatPojo result = jsonb.fromJson("{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 $$ 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"2017-03-03T11:11:10\",\"plainDateField\":\"2017-03-03T11:11:10\",\"setterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"setterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\"}", DateFormatPojo.class);
+        DateFormatPojo result = defaultJsonb.fromJson("{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 $$ 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"2017-03-03T11:11:10\",\"plainDateField\":\"2017-03-03T11:11:10\",\"setterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"setterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\"}", DateFormatPojo.class);
 
         assertEquals(timeCalendar.getTime(), result.plainDateField);
         assertEquals(timeCalendar.getTime(), result.formattedDateField);
@@ -104,7 +103,7 @@ public class JsonbDateFormatterTest {
 
         String expectedJson = "{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"plainDateField\":\"11:11:10 ^ 03-03-2017\",\"setterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"setterFormattedDateField\":\"11:11:10 ^ 03-03-2017\"}";
 
-        assertEquals(expectedJson, jsonb.toJson(dateFormatPojo));
+        assertEquals(expectedJson, defaultJsonb.toJson(dateFormatPojo));
     }
 
     @Test
@@ -115,7 +114,7 @@ public class JsonbDateFormatterTest {
                 .setTimeZone(TimeZone.getTimeZone("UTC"))
                 .build();
 
-        DateFormatPojoWithClassLevelFormatter result = jsonb.fromJson("{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 $$ 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"11:11:10 ^ 03-03-2017\",\"plainDateField\":\"11:11:10 ^ 03-03-2017\",\"setterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"setterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\"}", DateFormatPojoWithClassLevelFormatter.class);
+        DateFormatPojoWithClassLevelFormatter result = defaultJsonb.fromJson("{\"formattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterAndSetterAndFieldFormattedDateField\":\"11:11:10 $$ 03-03-2017\",\"getterAndSetterFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"getterAndFieldFormattedDateField\":\"11:11:10 ^^ 03-03-2017\",\"getterFormattedDateField\":\"11:11:10 ^ 03-03-2017\",\"plainDateField\":\"11:11:10 ^ 03-03-2017\",\"setterAndFieldFormattedDateField\":\"11:11:10 <> 03-03-2017\",\"setterFormattedDateField\":\"11:11:10 ^^ 03-03-2017\"}", DateFormatPojoWithClassLevelFormatter.class);
 
         assertEquals(timeCalendar.getTime(), result.plainDateField);
         assertEquals(timeCalendar.getTime(), result.formattedDateField);
@@ -129,10 +128,8 @@ public class JsonbDateFormatterTest {
 
     @Test
     public void testTrimmedDateParsing() {
-
         ZoneId utcZone = ZoneId.of("UTC");
         ZonedDateTime zdt = ZonedDateTime.of(2018, 1, 30, 0, 0, 0, 0, utcZone);
-
 
         TrimmedDatePojo pojo = new TrimmedDatePojo();
         pojo.setDate(Date.from(zdt.toInstant()));

--- a/src/test/java/org/eclipse/yasson/customization/JsonbDateFormatterTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbDateFormatterTest.java
@@ -13,11 +13,13 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.DateFormatPojo;
 import org.eclipse.yasson.customization.model.DateFormatPojoWithClassLevelFormatter;
 import org.eclipse.yasson.customization.model.TrimmedDatePojo;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -29,7 +31,6 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static org.eclipse.yasson.YassonProperties.ZERO_TIME_PARSE_DEFAULTING;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests customization of date fields via {@link javax.json.bind.annotation.JsonbDateFormat} annotation

--- a/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.JsonbNillableClassSecondLevel;
 import org.eclipse.yasson.customization.model.JsonbNillableOverriddenWithJsonbProperty;
@@ -35,35 +36,28 @@ import javax.json.bind.JsonbConfig;
  */
 public class JsonbNillableTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void setUp() throws Exception {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testJsonbNillable() {
         JsonbNillableValue pojo = new JsonbNillableValue();
-        assertEquals("{\"nillableField\":null}", jsonb.toJson(pojo));
+        assertEquals("{\"nillableField\":null}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testJsonbNillableOverriddenWithJsonbProperty() {
         JsonbNillableOverriddenWithJsonbProperty pojo = new JsonbNillableOverriddenWithJsonbProperty();
-        assertEquals("{}", jsonb.toJson(pojo));
+        assertEquals("{}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testPackageLevelNillable() {
         JsonbNillablePackageLevel pojo = new JsonbNillablePackageLevel();
-        assertEquals("{\"packageLevelNillableField\":null}", jsonb.toJson(pojo));
+        assertEquals("{\"packageLevelNillableField\":null}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testPackageLevelOverriddenWithClassLevel() {
         PackageLevelOverriddenWithClassLevel pojo = new PackageLevelOverriddenWithClassLevel();
-        assertEquals("{}", jsonb.toJson(pojo));
+        assertEquals("{}", defaultJsonb.toJson(pojo));
     }
 
     /**
@@ -72,16 +66,16 @@ public class JsonbNillableTest {
     @Test
     public void testNillableInheritFromInterface() throws Exception {
         JsonbNillableClassSecondLevel pojo = new JsonbNillableClassSecondLevel();
-        assertEquals("{\"classNillable\":null}", jsonb.toJson(pojo));
+        assertEquals("{\"classNillable\":null}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testInheritanceOverride() throws Exception {
         JsonbNillableOverridesInterface overridesInterface = new JsonbNillableOverridesInterface();
-        assertEquals("{}", jsonb.toJson(overridesInterface));
+        assertEquals("{}", defaultJsonb.toJson(overridesInterface));
 
         JsonbNillableOverridesClass overridesClass = new JsonbNillableOverridesClass();
-        assertEquals("{}", jsonb.toJson(overridesClass));
+        assertEquals("{}", defaultJsonb.toJson(overridesClass));
     }
 
     @Test
@@ -90,7 +84,7 @@ public class JsonbNillableTest {
         Jsonb jsonb = JsonbBuilder.create(jsonbConfig);
 
         String jsonString = jsonb.toJson(new ScalarValueWrapper<String>(){});
-        Assert.assertEquals("{\"value\":null}", jsonString);
+        assertEquals("{\"value\":null}", jsonString);
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
@@ -26,10 +26,6 @@ import org.eclipse.yasson.customization.model.packagelevelannotations.JsonbNilla
 import org.eclipse.yasson.customization.model.packagelevelannotations.PackageLevelOverriddenWithClassLevel;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbConfig;
-
 /**
  * Tests a {@link javax.json.bind.annotation.JsonbNillable} annotation.
  * @author Roman Grigoriadi
@@ -80,11 +76,7 @@ public class JsonbNillableTest {
 
     @Test
     public void testNillableInConfig() {
-        JsonbConfig jsonbConfig = new JsonbConfig().withNullValues(true);
-        Jsonb jsonb = JsonbBuilder.create(jsonbConfig);
-
-        String jsonString = jsonb.toJson(new ScalarValueWrapper<String>(){});
+        String jsonString = nullableJsonb.toJson(new ScalarValueWrapper<String>(){});
         assertEquals("{\"value\":null}", jsonString);
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbNillableTest.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.JsonbNillableClassSecondLevel;
 import org.eclipse.yasson.customization.model.JsonbNillableOverriddenWithJsonbProperty;
 import org.eclipse.yasson.customization.model.JsonbNillableOverridesClass;
@@ -21,15 +24,10 @@ import org.eclipse.yasson.customization.model.JsonbNillableValue;
 import org.eclipse.yasson.customization.model.packagelevelannotations.JsonbNillablePackageLevel;
 import org.eclipse.yasson.customization.model.packagelevelannotations.PackageLevelOverriddenWithClassLevel;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests a {@link javax.json.bind.annotation.JsonbNillable} annotation.

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.JsonbPropertyName;
 import org.eclipse.yasson.customization.model.JsonbPropertyNameCollision;
 import org.eclipse.yasson.customization.model.JsonbPropertyNillable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -26,8 +26,6 @@ import javax.json.bind.JsonbConfig;
 import javax.json.bind.JsonbException;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.config.PropertyNamingStrategy;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests parsing of {@link javax.json.bind.annotation.JsonbProperty} test.

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
@@ -126,11 +126,10 @@ public class JsonbPropertyTest {
         ConflictingWithUpperCamelStrategy pojo = new ConflictingWithUpperCamelStrategy();
         pojo.setDOI("DOI value");
 
-        Jsonb jsonb = JsonbBuilder.create();
-        String json = jsonb.toJson(pojo);
+        String json = defaultJsonb.toJson(pojo);
         assertEquals("{\"Doi\":\"DOI value\",\"doi\":\"DOI value\"}", json);
 
-        jsonb = JsonbBuilder.create(new JsonbConfig()
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
                 .withPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE));
 
         try {
@@ -184,8 +183,6 @@ public class JsonbPropertyTest {
         }
     }
 
-
-
     public static class ConflictingWithUpperCamelStrategy {
         public String doi;
 
@@ -197,6 +194,4 @@ public class JsonbPropertyTest {
             this.doi = doi;
         }
     }
-
-
 }

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.JsonbPropertyName;
 import org.eclipse.yasson.customization.model.JsonbPropertyNameCollision;
@@ -33,13 +34,6 @@ import javax.json.bind.config.PropertyNamingStrategy;
  */
 public class JsonbPropertyTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void setUp() throws Exception {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testPropertyName() throws Exception {
 
@@ -49,10 +43,10 @@ public class JsonbPropertyTest {
         pojo.setFieldOverriddenWithMethodAnnot("OVERRIDDEN_GETTER");
 
         assertEquals("{\"fieldAnnotatedNameCustomized\":\"FIELD_ANNOTATED\",\"getterAnnotatedName\":\"METHOD_ANNOTATED\",\"getterOverriddenName\":\"OVERRIDDEN_GETTER\"}",
-                jsonb.toJson(pojo));
+                defaultJsonb.toJson(pojo));
 
         String toUnmarshall = "{\"fieldAnnotatedNameCustomized\":\"FIELD_ANNOTATED\",\"setterOverriddenName\":\"OVERRIDDEN_GETTER\",\"setterAnnotatedName\":\"METHOD_ANNOTATED\"}";
-        JsonbPropertyName result = jsonb.fromJson(toUnmarshall, JsonbPropertyName.class);
+        JsonbPropertyName result = defaultJsonb.fromJson(toUnmarshall, JsonbPropertyName.class);
         assertEquals("FIELD_ANNOTATED", result.getFieldAnnotatedName());
         assertEquals("METHOD_ANNOTATED", result.getMethodAnnotName());
         assertEquals("OVERRIDDEN_GETTER", result.getFieldOverriddenWithMethodAnnot());
@@ -61,13 +55,13 @@ public class JsonbPropertyTest {
     @Test
     public void testNameCollision() {
         JsonbPropertyNameCollision nameCollisionPojo = new JsonbPropertyNameCollision();
-        tryClash(()->jsonb.toJson(nameCollisionPojo));
-        tryClash(()->jsonb.fromJson("{}", JsonbPropertyNameCollision.class));
+        tryClash(() -> defaultJsonb.toJson(nameCollisionPojo));
+        tryClash(() -> defaultJsonb.fromJson("{}", JsonbPropertyNameCollision.class));
     }
 
 
 
-    private void tryClash(Runnable clashCommand) {
+    private static void tryClash(Runnable clashCommand) {
         try {
             clashCommand.run();
             fail();
@@ -80,7 +74,7 @@ public class JsonbPropertyTest {
     @Test
     public void testPropertyNillable() {
         JsonbPropertyNillable pojo = new JsonbPropertyNillable();
-        assertEquals("{\"nullField\":null}", jsonb.toJson(pojo));
+        assertEquals("{\"nullField\":null}", defaultJsonb.toJson(pojo));
     }
 
     /**
@@ -98,11 +92,11 @@ public class JsonbPropertyTest {
         NonConflictingProperties nonConflictingProperties = new NonConflictingProperties();
         nonConflictingProperties.setDOI("DOI value");
 
-        String json = jsonb.toJson(nonConflictingProperties);
-        Assert.assertEquals("{\"doi\":\"DOI value\"}", json);
+        String json = defaultJsonb.toJson(nonConflictingProperties);
+        assertEquals("{\"doi\":\"DOI value\"}", json);
 
-        NonConflictingProperties result = jsonb.fromJson("{\"DOI\":\"DOI value\"}", NonConflictingProperties.class);
-        Assert.assertEquals("DOI value", result.getDOI());
+        NonConflictingProperties result = defaultJsonb.fromJson("{\"DOI\":\"DOI value\"}", NonConflictingProperties.class);
+        assertEquals("DOI value", result.getDOI());
     }
 
     /**
@@ -112,8 +106,7 @@ public class JsonbPropertyTest {
     public void testConflictingProperties() {
         ConflictingProperties conflictingProperties = new ConflictingProperties();
         conflictingProperties.setDOI("DOI value");
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
-        );
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig());
 
         try {
             jsonb.toJson(conflictingProperties);
@@ -135,7 +128,7 @@ public class JsonbPropertyTest {
 
         Jsonb jsonb = JsonbBuilder.create();
         String json = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"Doi\":\"DOI value\",\"doi\":\"DOI value\"}", json);
+        assertEquals("{\"Doi\":\"DOI value\",\"doi\":\"DOI value\"}", json);
 
         jsonb = JsonbBuilder.create(new JsonbConfig()
                 .withPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE));

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyVisibilityStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyVisibilityStrategyTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -157,8 +158,7 @@ public class JsonbPropertyVisibilityStrategyTest {
 
     @Test
     public void testAnnotatedPojo() {
-        final Jsonb jsonb = JsonbBuilder.create();
         AnnotatedPojo fieldPojo = new AnnotatedPojo("avalue", "bvalue", "cvalue", "dvalue");
-        assertEquals("{\"bfield\":\"bvalue\",\"bgetter\":\"bvalue\",\"cfield\":\"cvalue\",\"cgetter\":\"cvalue\"}", jsonb.toJson(fieldPojo));
+        assertEquals("{\"bfield\":\"bvalue\",\"bgetter\":\"bvalue\",\"cfield\":\"cvalue\",\"cgetter\":\"cvalue\"}", defaultJsonb.toJson(fieldPojo));
     }
 }

--- a/src/test/java/org/eclipse/yasson/customization/JsonbPropertyVisibilityStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/JsonbPropertyVisibilityStrategyTest.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.yasson.customization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -22,8 +23,6 @@ import javax.json.bind.annotation.JsonbVisibility;
 import javax.json.bind.config.PropertyVisibilityStrategy;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests custom {@link PropertyVisibilityStrategy}

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -33,7 +33,7 @@ import javax.json.bind.JsonbConfig;
 public class NumberFormatTest {
     private Jsonb jsonb;
 
-    @Before
+    @BeforeAll
     public void setUp() {
         jsonb = JsonbBuilder.create(new JsonbConfig().withLocale(Locale.US));
     }

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -13,10 +13,11 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.NumberFormatPojo;
 import org.eclipse.yasson.customization.model.NumberFormatPojoWithoutClassLevelFormatter;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -24,8 +25,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 import javax.json.bind.JsonbConfig;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests number format.

--- a/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/NumberFormatTest.java
@@ -31,12 +31,7 @@ import javax.json.bind.JsonbConfig;
  * @author Roman Grigoriadi
  */
 public class NumberFormatTest {
-    private Jsonb jsonb;
-
-    @BeforeAll
-    public void setUp() {
-        jsonb = JsonbBuilder.create(new JsonbConfig().withLocale(Locale.US));
-    }
+    private static final Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withLocale(Locale.US));
 
     @Test
     public void testSerialize() {

--- a/src/test/java/org/eclipse/yasson/customization/PrettyPrintTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/PrettyPrintTest.java
@@ -15,10 +15,8 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbConfig;
 import java.util.Arrays;
 
 /**
@@ -30,18 +28,11 @@ public class PrettyPrintTest {
 
     @Test
     public void testPrettyPrint() {
-        final JsonbConfig config = new JsonbConfig();
-        config.setProperty(JsonbConfig.FORMATTING, Boolean.TRUE);
-        final Jsonb jsonb = JsonbBuilder.create(config);
-        assertEquals("\n[\n    \"first\",\n    \"second\"\n]", jsonb.toJson(Arrays.asList("first", "second")));
+        assertEquals("\n[\n    \"first\",\n    \"second\"\n]", formattingJsonb.toJson(Arrays.asList("first", "second")));
     }
 
     @Test
     public void testPrettyPrintFalse() {
-        final JsonbConfig config = new JsonbConfig();
-        config.setProperty(JsonbConfig.FORMATTING, Boolean.FALSE);
-        final Jsonb jsonb = JsonbBuilder.create(config);
-        assertEquals("[\"first\",\"second\"]", jsonb.toJson(Arrays.asList("first", "second")));
+        assertEquals("[\"first\",\"second\"]", defaultJsonb.toJson(Arrays.asList("first", "second")));
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/customization/PrettyPrintTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/PrettyPrintTest.java
@@ -13,14 +13,13 @@
 
 package org.eclipse.yasson.customization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests pretty print to JSONP propagation

--- a/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
@@ -90,16 +90,16 @@ public class PropertyOrderTest {
         Jsonb jsonb = JsonbBuilder.create(config);
 
         String jsonString = jsonb.toJson(new RenamedPropertiesContainer() {{ setStringInstance("Test String"); setLongInstance(1); }});
-        Assert.assertTrue(jsonString.matches("\\{\\s*\"first\"\\s*\\:\\s*0\\s*,\\s*\"second\"\\s*\\:\\s*\"Test String\"\\s*,\\s*\"third\"\\s*\\:\\s*1\\s*\\}"));
+        assertTrue(jsonString.matches("\\{\\s*\"first\"\\s*\\:\\s*0\\s*,\\s*\"second\"\\s*\\:\\s*\"Test String\"\\s*,\\s*\"third\"\\s*\\:\\s*1\\s*\\}"));
 
         RenamedPropertiesContainer unmarshalledObject = jsonb.fromJson("{ \"first\" : 1, \"second\" : \"Test String\", \"third\" : 1 }", RenamedPropertiesContainer.class);
-        Assert.assertEquals(3, unmarshalledObject.getIntInstance());
+        assertEquals(3, unmarshalledObject.getIntInstance());
     }
 
     @Test
     public void testJsonbPropertyOrderOnRenamedProperties() {
         Jsonb jsonb = JsonbBuilder.create();
-        Assert.assertEquals("{\"from\":10,\"count\":11}", jsonb.toJson(new Range(10, 11)));
+        assertEquals("{\"from\":10,\"count\":11}", jsonb.toJson(new Range(10, 11)));
     }
 
     @JsonbPropertyOrder(

--- a/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.customization;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.model.FieldCustomOrder;
 import org.eclipse.yasson.customization.model.FieldCustomOrderWrapper;
@@ -62,11 +63,11 @@ public class PropertyOrderTest {
 
     @Test
     public void testPropertySetCustomOrder() {
-        Jsonb jsonb = JsonbBuilder.create();
         FieldSpecificOrder fieldSpecificOrder = new FieldSpecificOrder();
         String expectedSpecific = "{\"aField\":\"aValue\",\"dField\":\"dValue\",\"bField\":\"bValue\",\"cField\":\"cValue\"}";
-        assertEquals(expectedSpecific, jsonb.toJson(fieldSpecificOrder));
-        jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.REVERSE));
+        assertEquals(expectedSpecific, defaultJsonb.toJson(fieldSpecificOrder));
+        
+        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.REVERSE));
         expectedSpecific = "{\"aField\":\"aValue\",\"dField\":\"dValue\",\"cField\":\"cValue\",\"bField\":\"bValue\"}";
         assertEquals(expectedSpecific, jsonb.toJson(fieldSpecificOrder));
     }
@@ -98,8 +99,7 @@ public class PropertyOrderTest {
 
     @Test
     public void testJsonbPropertyOrderOnRenamedProperties() {
-        Jsonb jsonb = JsonbBuilder.create();
-        assertEquals("{\"from\":10,\"count\":11}", jsonb.toJson(new Range(10, 11)));
+        assertEquals("{\"from\":10,\"count\":11}", defaultJsonb.toJson(new Range(10, 11)));
     }
 
     @JsonbPropertyOrder(

--- a/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/PropertyOrderTest.java
@@ -13,14 +13,15 @@
 
 package org.eclipse.yasson.customization;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.model.FieldCustomOrder;
 import org.eclipse.yasson.customization.model.FieldCustomOrderWrapper;
 import org.eclipse.yasson.customization.model.FieldOrder;
 import org.eclipse.yasson.customization.model.FieldOrderNameAnnotation;
 import org.eclipse.yasson.customization.model.FieldSpecificOrder;
 import org.eclipse.yasson.customization.model.RenamedPropertiesContainer;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -29,8 +30,6 @@ import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.config.PropertyOrderStrategy;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/customization/transients/JsonbTransientTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/transients/JsonbTransientTest.java
@@ -15,24 +15,15 @@ package org.eclipse.yasson.customization.transients;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.customization.transients.models.*;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 
 /**
  * @author Roman Grigoriadi
  */
 public class JsonbTransientTest {
-
-    private Jsonb jsonb;
-
-    @Before
-    public void setUp() throws Exception {
-        jsonb = JsonbBuilder.create();
-    }
 
     @Test
     public void testJsonbTransientPropertySerialize() {
@@ -46,12 +37,12 @@ public class JsonbTransientTest {
         pojo.setSetterAndGetterTransient("Setter and getter transient value");
         pojo.setSetterAndGetterAndPropertyTransient("Setter and getter and property transient value");
 
-        assertEquals("{\"plainProperty\":\"non transient\",\"setterTransient\":\"Setter transient value\"}", jsonb.toJson(pojo));
+        assertEquals("{\"plainProperty\":\"non transient\",\"setterTransient\":\"Setter transient value\"}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testJsonbTransientPropertyDeserialize() {
-        JsonbTransientValue result = jsonb.fromJson("{\"plainProperty\":\"plainProperty value\"," +
+        JsonbTransientValue result = defaultJsonb.fromJson("{\"plainProperty\":\"plainProperty value\"," +
                         "\"propertyTransient\":\"TRANSIENT\"," +
                         "\"getterTransient\":\"Getter transient value\"," +
                         "\"setterTransient\":\"Setter transient value\"," +
@@ -78,7 +69,7 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
@@ -91,7 +82,7 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
@@ -104,7 +95,7 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
@@ -117,7 +108,7 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
@@ -130,7 +121,7 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
@@ -143,35 +134,38 @@ public class JsonbTransientTest {
         pojo.setTransientProperty("TRANSIENT");
 
         try {
-            jsonb.toJson(pojo);
+        	defaultJsonb.toJson(pojo);
             fail();
         } catch (JsonbException e) {
             assertTrue(e.getMessage().startsWith("JsonbTransient annotation cannot be used with other jsonb annotations on the same property."));
         }
     }
 
-    @Test(expected = JsonbException.class)
+    @Test
     public void testTransientGetterPlusJsonbPropertyField() {
-        TransientGetterPlusCustomizationAnnotatedFieldContainer pojo = new TransientGetterPlusCustomizationAnnotatedFieldContainer();
-        jsonb.toJson(pojo);
+    	assertThrows(JsonbException.class, () -> {
+	        TransientGetterPlusCustomizationAnnotatedFieldContainer pojo = new TransientGetterPlusCustomizationAnnotatedFieldContainer();
+	        defaultJsonb.toJson(pojo);
+    	});
     }
 
-    @Test(expected = JsonbException.class)
+    @Test
     public void testTransientSetterPlusJsonbPropertyField() {
-        TransientSetterPlusCustomizationAnnotatedFieldContainer pojo = new TransientSetterPlusCustomizationAnnotatedFieldContainer();
-        jsonb.toJson(pojo);
+    	assertThrows(JsonbException.class, () -> {
+	        TransientSetterPlusCustomizationAnnotatedFieldContainer pojo = new TransientSetterPlusCustomizationAnnotatedFieldContainer();
+	        defaultJsonb.toJson(pojo);
+    	});
     }
 
     @Test
     public void testTransientSetterplusJsonbPropertyGetter() {
         TransientSetterPlusCustomizationAnnotatedGetterContainer pojo = new TransientSetterPlusCustomizationAnnotatedGetterContainer();
-        String result = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"instance\":\"INSTANCE\"}", result);
+        assertEquals("{\"instance\":\"INSTANCE\"}", defaultJsonb.toJson(pojo));
     }
 
     @Test
     public void testTransientGetterNoField() {
         TransientGetterNoField pojo = new TransientGetterNoField();
-        assertEquals("{}", jsonb.toJson(pojo));
+        assertEquals("{}", defaultJsonb.toJson(pojo));
     }
 }

--- a/src/test/java/org/eclipse/yasson/customization/transients/JsonbTransientTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/transients/JsonbTransientTest.java
@@ -13,16 +13,14 @@
 
 package org.eclipse.yasson.customization.transients;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.customization.transients.models.*;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
@@ -1,15 +1,14 @@
 package org.eclipse.yasson.defaultmapping;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.collections.Language;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 public class EnumTest {
 
@@ -19,23 +18,23 @@ public class EnumTest {
     public void testEnumValue() {
         assertEquals("\"Russian\"", jsonb.toJson(Language.Russian));
         Language result = jsonb.fromJson("\"Russian\"", Language.class);
-        Assert.assertEquals(Language.Russian, result);
+        assertEquals(Language.Russian, result);
     }
 
     @Test
     public void testEnumInObject() {
-        Assert.assertEquals("{\"value\":\"Russian\"}", jsonb.toJson(new ScalarValueWrapper<>(Language.Russian)));
+        assertEquals("{\"value\":\"Russian\"}", jsonb.toJson(new ScalarValueWrapper<>(Language.Russian)));
         ScalarValueWrapper<Language> result = jsonb.fromJson("{\"value\":\"Russian\"}", new TestTypeToken<ScalarValueWrapper<Language>>() {
         }.getType());
 
-        Assert.assertEquals(result.getValue(), Language.Russian);
+        assertEquals(result.getValue(), Language.Russian);
     }
 
     @Test
     public void testEnumValueWithToStringOverriden() {
         assertEquals("\"HARD_BACK\"", jsonb.toJson(Binding.HARD_BACK));
         Binding result = jsonb.fromJson("\"HARD_BACK\"", Binding.class);
-        Assert.assertEquals(Binding.HARD_BACK, result);
+        assertEquals(Binding.HARD_BACK, result);
     }
 
 
@@ -43,7 +42,7 @@ public class EnumTest {
     public void testEnumInObjectWithToStringOverriden() {
         assertEquals("{\"value\":\"HARD_BACK\"}", jsonb.toJson(new ScalarValueWrapper<>(Binding.HARD_BACK)));
         ScalarValueWrapper<Binding> result = jsonb.fromJson("{\"value\":\"HARD_BACK\"}", new TestTypeToken<ScalarValueWrapper<Binding>>(){}.getType());
-        Assert.assertEquals(Binding.HARD_BACK, result.getValue());
+        assertEquals(Binding.HARD_BACK, result.getValue());
     }
 
     public enum Binding {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/EnumTest.java
@@ -2,29 +2,25 @@ package org.eclipse.yasson.defaultmapping;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.collections.Language;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-
 public class EnumTest {
-
-    private final Jsonb jsonb = JsonbBuilder.create();
 
     @Test
     public void testEnumValue() {
-        assertEquals("\"Russian\"", jsonb.toJson(Language.Russian));
-        Language result = jsonb.fromJson("\"Russian\"", Language.class);
+        assertEquals("\"Russian\"", defaultJsonb.toJson(Language.Russian));
+        Language result = defaultJsonb.fromJson("\"Russian\"", Language.class);
         assertEquals(Language.Russian, result);
     }
 
     @Test
     public void testEnumInObject() {
-        assertEquals("{\"value\":\"Russian\"}", jsonb.toJson(new ScalarValueWrapper<>(Language.Russian)));
-        ScalarValueWrapper<Language> result = jsonb.fromJson("{\"value\":\"Russian\"}", new TestTypeToken<ScalarValueWrapper<Language>>() {
+        assertEquals("{\"value\":\"Russian\"}", defaultJsonb.toJson(new ScalarValueWrapper<>(Language.Russian)));
+        ScalarValueWrapper<Language> result = defaultJsonb.fromJson("{\"value\":\"Russian\"}", new TestTypeToken<ScalarValueWrapper<Language>>() {
         }.getType());
 
         assertEquals(result.getValue(), Language.Russian);
@@ -32,22 +28,22 @@ public class EnumTest {
 
     @Test
     public void testEnumValueWithToStringOverriden() {
-        assertEquals("\"HARD_BACK\"", jsonb.toJson(Binding.HARD_BACK));
-        Binding result = jsonb.fromJson("\"HARD_BACK\"", Binding.class);
+        assertEquals("\"HARD_BACK\"", defaultJsonb.toJson(Binding.HARD_BACK));
+        Binding result = defaultJsonb.fromJson("\"HARD_BACK\"", Binding.class);
         assertEquals(Binding.HARD_BACK, result);
     }
 
-
     @Test
     public void testEnumInObjectWithToStringOverriden() {
-        assertEquals("{\"value\":\"HARD_BACK\"}", jsonb.toJson(new ScalarValueWrapper<>(Binding.HARD_BACK)));
-        ScalarValueWrapper<Binding> result = jsonb.fromJson("{\"value\":\"HARD_BACK\"}", new TestTypeToken<ScalarValueWrapper<Binding>>(){}.getType());
+        assertEquals("{\"value\":\"HARD_BACK\"}", defaultJsonb.toJson(new ScalarValueWrapper<>(Binding.HARD_BACK)));
+        ScalarValueWrapper<Binding> result = defaultJsonb.fromJson("{\"value\":\"HARD_BACK\"}", new TestTypeToken<ScalarValueWrapper<Binding>>(){}.getType());
         assertEquals(Binding.HARD_BACK, result.getValue());
     }
 
     public enum Binding {
         HARD_BACK {
-            public String toString() {
+            @Override
+			public String toString() {
                 return "Hard Back";
             }
         }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/IJsonTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/IJsonTest.java
@@ -1,9 +1,10 @@
 package org.eclipse.yasson.defaultmapping;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -28,11 +29,11 @@ public class IJsonTest {
         calendar.setTimeZone(TimeZone.getTimeZone("Europe/Paris"));
 
         String jsonString = jsonb.toJson(new ScalarValueWrapper<>(calendar));
-        Assert.assertEquals("{\"value\":\"1970-01-01T00:00:00Z+01:00\"}", jsonString);
+        assertEquals("{\"value\":\"1970-01-01T00:00:00Z+01:00\"}", jsonString);
 
         ScalarValueWrapper<Calendar> result = jsonb.fromJson("{\"value\":\"1970-01-01T00:00:00Z+01:00\"}", new TestTypeToken<ScalarValueWrapper<Calendar>>() {}.getType());
 
-        Assert.assertEquals(calendar.toInstant(), result.getValue().toInstant());
+        assertEquals(calendar.toInstant(), result.getValue().toInstant());
     }
 
     @Test
@@ -43,10 +44,10 @@ public class IJsonTest {
         calendar.clear(Calendar.MILLISECOND);
 
         String jsonString = jsonb.toJson(new ScalarValueWrapper<>(calendar.getTime()));
-        Assert.assertTrue(jsonString.matches("\\{\"value\":\"1970-01-01T00:00:00Z\\+[0-9]{2}:[0-9]{2}\"}"));
+        assertTrue(jsonString.matches("\\{\"value\":\"1970-01-01T00:00:00Z\\+[0-9]{2}:[0-9]{2}\"}"));
 
         ScalarValueWrapper<Date> result = jsonb.fromJson("{\"value\":\"1970-01-01T00:00:00Z+00:00\"}", new TestTypeToken<ScalarValueWrapper<Date>>(){}.getType());
-        Assert.assertEquals(0, result.getValue().compareTo(calendar.getTime()));
+        assertEquals(0, result.getValue().compareTo(calendar.getTime()));
 
     }
 
@@ -54,22 +55,22 @@ public class IJsonTest {
     public void testStrictInstant() {
         Instant instant = LocalDateTime.of(2017, 3, 24, 12,0,0).toInstant(ZoneOffset.MIN);
         final String json = jsonb.toJson(new ScalarValueWrapper<>(instant));
-        Assert.assertEquals("{\"value\":\"2017-03-25T06:00:00Z+00:00\"}", json);
+        assertEquals("{\"value\":\"2017-03-25T06:00:00Z+00:00\"}", json);
         ScalarValueWrapper<Instant> result = jsonb.fromJson("{\"value\":\"2017-03-25T06:00:00Z+00:00\"}", new TestTypeToken<ScalarValueWrapper<Instant>>() {}.getType());
-        Assert.assertEquals(instant, result.getValue());
+        assertEquals(instant, result.getValue());
     }
 
     @Test
     public void testLocalDate() {
         final LocalDate localDate = LocalDate.of(1970, 1, 1);
         final String json = jsonb.toJson(new ScalarValueWrapper<>(localDate));
-        Assert.assertEquals("{\"value\":\"1970-01-01T00:00:00Z+00:00\"}", json);
+        assertEquals("{\"value\":\"1970-01-01T00:00:00Z+00:00\"}", json);
 
         ScalarValueWrapper<LocalDate> result = jsonb.fromJson("{\"value\":\"1970-01-01T00:00:00Z+00:00\"}", new TestTypeToken<ScalarValueWrapper<LocalDate>>() {
         }.getType());
 
 
-        Assert.assertEquals(localDate, result.getValue());
+        assertEquals(localDate, result.getValue());
     }
 
     @Test
@@ -77,13 +78,13 @@ public class IJsonTest {
         final LocalDateTime localDateTime = LocalDateTime.of(1970, 1, 1, 1, 1, 1);
         final String json = jsonb.toJson(new ScalarValueWrapper<>(localDateTime));
 
-        Assert.assertEquals("{\"value\":\"1970-01-01T01:01:01Z+00:00\"}", json);
+        assertEquals("{\"value\":\"1970-01-01T01:01:01Z+00:00\"}", json);
 
         ScalarValueWrapper<LocalDateTime> result = jsonb.fromJson("{\"value\":\"1970-01-01T01:01:01Z+00:00\"}", new TestTypeToken<ScalarValueWrapper<LocalDateTime>>() {
         }.getType());
 
 
-        Assert.assertEquals(localDateTime, result.getValue());
+        assertEquals(localDateTime, result.getValue());
     }
 
     @Test
@@ -91,10 +92,10 @@ public class IJsonTest {
         Duration duration = Duration.ofDays(1).plus(Duration.ofHours(1)).plus(Duration.ofSeconds(1));
 
         final String json = jsonb.toJson(new ScalarValueWrapper<>(duration));
-        Assert.assertEquals("{\"value\":\"PT25H1S\"}", json);
+        assertEquals("{\"value\":\"PT25H1S\"}", json);
 
         ScalarValueWrapper<Duration> result = jsonb.fromJson(json, new TestTypeToken<ScalarValueWrapper<Duration>>() {
         }.getType());
-        Assert.assertEquals(duration, result.getValue());
+        assertEquals(duration, result.getValue());
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
@@ -1,7 +1,6 @@
 package org.eclipse.yasson.defaultmapping;
 
 import org.junit.jupiter.api.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.yasson.serializers.model.Crate;
 
@@ -22,14 +21,14 @@ public class SecurityManagerTest {
 
     static final String classesDir = SecurityManagerTest.class.getProtectionDomain().getCodeSource().getLocation().getFile();
 
-    @Before
+    @BeforeAll
     public void setUp() {
         System.setProperty("java.security.policy", classesDir + "test.policy");
         System.setProperty("java.security.debug", "failure");
         System.setSecurityManager(new SecurityManager());
     }
 
-    @After
+    @AfterAll
     public void tearDown() {
         System.setSecurityManager(null);
     }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
@@ -1,9 +1,9 @@
 package org.eclipse.yasson.defaultmapping;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.serializers.model.Crate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;

--- a/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/SecurityManagerTest.java
@@ -22,14 +22,14 @@ public class SecurityManagerTest {
     static final String classesDir = SecurityManagerTest.class.getProtectionDomain().getCodeSource().getLocation().getFile();
 
     @BeforeAll
-    public void setUp() {
+    public static void setUp() {
         System.setProperty("java.security.policy", classesDir + "test.policy");
         System.setProperty("java.security.debug", "failure");
         System.setSecurityManager(new SecurityManager());
     }
 
     @AfterAll
-    public void tearDown() {
+    public static void tearDown() {
         System.setSecurityManager(null);
     }
 

--- a/src/test/java/org/eclipse/yasson/defaultmapping/anonymous/AnonymousClassTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/anonymous/AnonymousClassTest.java
@@ -14,9 +14,7 @@ package org.eclipse.yasson.defaultmapping.anonymous;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
+import static org.eclipse.yasson.Jsonbs.*;
 
 /**
  * This class contains tests for marshalling/unmarshalling anonymous classes.
@@ -25,16 +23,9 @@ import javax.json.bind.JsonbBuilder;
  */
 public class AnonymousClassTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testMarshallInnerClass() {
-        assertEquals("{\"anonymousField\":\"anonymousValue\",\"id\":1,\"name\":\"pojoName\"}", jsonb.toJson(new InnerPojo() {
+        assertEquals("{\"anonymousField\":\"anonymousValue\",\"id\":1,\"name\":\"pojoName\"}", defaultJsonb.toJson(new InnerPojo() {
             public String anonymousField = "anonymousValue";
 
             @Override
@@ -51,7 +42,7 @@ public class AnonymousClassTest {
 
     @Test
     public void testMarshallOuterClass() {
-        assertEquals("{\"id\":1,\"anonymousField\":\"anonymousValue\"}", jsonb.toJson(new OuterPojo() {
+        assertEquals("{\"id\":1,\"anonymousField\":\"anonymousValue\"}", defaultJsonb.toJson(new OuterPojo() {
             public String anonymousField = "anonymousValue";
         }));
     }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/anonymous/AnonymousClassTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/anonymous/AnonymousClassTest.java
@@ -12,13 +12,11 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.anonymous;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * This class contains tests for marshalling/unmarshalling anonymous classes.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/BasicTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/BasicTest.java
@@ -12,16 +12,16 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.basic;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Default mapping primitives tests.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/BasicTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/BasicTest.java
@@ -14,10 +14,8 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
-import org.eclipse.yasson.internal.JsonBindingBuilder;
-
-import javax.json.bind.Jsonb;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -32,33 +30,27 @@ public class BasicTest {
 
     @Test
     public void testMarshallEscapedString() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("[\" \\\\ \\\" / \\f\\b\\r\\n\\t 9\"]", jsonb.toJson(new String[] {" \\ \" / \f\b\r\n\t \u0039"}));
+        assertEquals("[\" \\\\ \\\" / \\f\\b\\r\\n\\t 9\"]", bindingJsonb.toJson(new String[] {" \\ \" / \f\b\r\n\t \u0039"}));
     }
 
     @Test
     public void testMarshallWriter() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
         Writer writer = new StringWriter();
-        jsonb.toJson(new Long[]{5L}, writer);
+        bindingJsonb.toJson(new Long[]{5L}, writer);
         assertEquals("[5]", writer.toString());
     }
 
     @Test
     public void testMarshallOutputStream() throws IOException {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            jsonb.toJson(new Long[]{5L}, baos);
+        	bindingJsonb.toJson(new Long[]{5L}, baos);
             assertEquals("[5]", baos.toString("UTF-8"));
         }
     }
 
     @Test
     public void testObjectSerialization() {
-        Jsonb jsonb = (new JsonBindingBuilder()).build();
-        final String val =  jsonb.toJson(new Object());
+        final String val = bindingJsonb.toJson(new Object());
         assertEquals("{}", val);
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/BooleanTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/BooleanTest.java
@@ -13,16 +13,13 @@
 
 package org.eclipse.yasson.defaultmapping.basic;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.basic.model.BooleanModel;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests serialization and deserialization of boolean values.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/BooleanTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/BooleanTest.java
@@ -15,11 +15,9 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.defaultmapping.basic.model.BooleanModel;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 /**
  * Tests serialization and deserialization of boolean values.
@@ -27,39 +25,37 @@ import javax.json.bind.JsonbBuilder;
  * @author Ehsan Zaery Moghaddam (zaerymoghaddam@gmail.com)
  */
 public class BooleanTest {
-    private Jsonb jsonb = JsonbBuilder.create();
 
     @Test
     public void testBooleanSerialization() throws Exception {
         BooleanModel booleanModel = new BooleanModel(true, false);
 
         String expected = "{\"field1\":true,\"field2\":false}";
-        assertEquals(expected, jsonb.toJson(booleanModel));
+        assertEquals(expected, defaultJsonb.toJson(booleanModel));
     }
 
     @Test
     public void testBooleanDeserializationFromBooleanAsStringValue() throws Exception {
-        BooleanModel booleanModel = jsonb.fromJson("{\"field1\":\"true\",\"field2\":\"true\"}", BooleanModel.class);
+        BooleanModel booleanModel = defaultJsonb.fromJson("{\"field1\":\"true\",\"field2\":\"true\"}", BooleanModel.class);
         assertEquals(true, booleanModel.field1);
         assertEquals(true, booleanModel.field2);
     }
 
     @Test
     public void testBooleanDeserializationFromBooleanRawValue() throws Exception {
-        BooleanModel booleanModel = jsonb.fromJson("{\"field1\":false,\"field2\":false}", BooleanModel.class);
+        BooleanModel booleanModel = defaultJsonb.fromJson("{\"field1\":false,\"field2\":false}", BooleanModel.class);
         assertEquals(false, booleanModel.field1);
         assertEquals(false, booleanModel.field2);
     }
 
     @Test
     public void testNakedBooleans() {
-        assertEquals(true, jsonb.fromJson("true", boolean.class));
-        assertEquals(true, jsonb.fromJson("true", Boolean.class));
-        assertEquals(false, jsonb.fromJson("false", boolean.class));
-        assertEquals(false, jsonb.fromJson("false", Boolean.class));
+        assertEquals(true, defaultJsonb.fromJson("true", boolean.class));
+        assertEquals(true, defaultJsonb.fromJson("true", Boolean.class));
+        assertEquals(false, defaultJsonb.fromJson("false", boolean.class));
+        assertEquals(false, defaultJsonb.fromJson("false", Boolean.class));
         
-        assertEquals("true", jsonb.toJson(true, boolean.class));
-        assertEquals("false", jsonb.toJson(Boolean.FALSE, Boolean.class));
+        assertEquals("true", defaultJsonb.toJson(true, boolean.class));
+        assertEquals("false", defaultJsonb.toJson(Boolean.FALSE, Boolean.class));
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
@@ -16,6 +16,7 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import static org.eclipse.yasson.Assertions.*;
 import org.eclipse.yasson.TestTypeToken;
@@ -26,9 +27,6 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonWriter;
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbException;
 import javax.json.stream.JsonGenerator;
 
 import java.io.StringWriter;
@@ -43,53 +41,51 @@ import java.util.Map;
  */
 public class NumberTest {
 
-    private Jsonb jsonb = JsonbBuilder.create();
-
     @Test
     public void testSerializeFloat() {
-        final String json = jsonb.toJson(0.35f);
+        final String json = defaultJsonb.toJson(0.35f);
         assertEquals("0.35", json);
 
-        Float result = jsonb.fromJson("0.35", Float.class);
+        Float result = defaultJsonb.fromJson("0.35", Float.class);
         assertEquals((Float) .35f, result);
     }
 
     @Test
     public void testBigDecimalMarshalling() {
-        String jsonString = jsonb.toJson(new BigDecimal("0.10000000000000001"));
+        String jsonString = defaultJsonb.toJson(new BigDecimal("0.10000000000000001"));
         assertEquals("0.10000000000000001", jsonString);
 
-        jsonString = jsonb.toJson(new BigDecimal("0.1000000000000001"));
+        jsonString = defaultJsonb.toJson(new BigDecimal("0.1000000000000001"));
         assertEquals("0.1000000000000001", jsonString);
 
-        BigDecimal result = jsonb.fromJson("0.10000000000000001", BigDecimal.class);
+        BigDecimal result = defaultJsonb.fromJson("0.10000000000000001", BigDecimal.class);
         assertEquals(new BigDecimal("0.10000000000000001"), result);
 
-        result = jsonb.fromJson("0.100000000000000001", BigDecimal.class);
+        result = defaultJsonb.fromJson("0.100000000000000001", BigDecimal.class);
         assertEquals(new BigDecimal("0.100000000000000001"), result);
     }
 
     @Test
     public void testBigDecimalIEEE748() {
-        String jsonString = jsonb.toJson(new BigDecimal("9007199254740991"));
+        String jsonString = defaultJsonb.toJson(new BigDecimal("9007199254740991"));
         assertEquals("9007199254740991", jsonString);
 
-        jsonString = jsonb.toJson(new BigDecimal("9007199254740992"));
+        jsonString = defaultJsonb.toJson(new BigDecimal("9007199254740992"));
         assertEquals("9007199254740992", jsonString);
 
-        jsonString = jsonb.toJson(new BigDecimal("9007199254740991.1"));
+        jsonString = defaultJsonb.toJson(new BigDecimal("9007199254740991.1"));
         assertEquals("9007199254740991.1", jsonString);
 
-        jsonString = jsonb.toJson(new BigDecimal(new BigInteger("1"), -400));
+        jsonString = defaultJsonb.toJson(new BigDecimal(new BigInteger("1"), -400));
         assertEquals(new BigDecimal(new BigInteger("1"), -400).toString(), jsonString);
     }
 
     @Test
     public void testBigIntegerIEEE748() {
-        String jsonString = jsonb.toJson(new BigInteger("9007199254740991"));
+        String jsonString = defaultJsonb.toJson(new BigInteger("9007199254740991"));
         assertEquals("9007199254740991", jsonString);
 
-        jsonString = jsonb.toJson(new BigInteger("9007199254740992"));
+        jsonString = defaultJsonb.toJson(new BigInteger("9007199254740992"));
         assertEquals("9007199254740992", jsonString);
     }
 
@@ -97,72 +93,71 @@ public class NumberTest {
     public void testBigDecimalInNumber() {
         BigDecimalInNumber testValueQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740992"));}};
         BigDecimalInNumber testValueUnQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740991"));}};
-        String jsonString = jsonb.toJson(testValueQuoted);
+        String jsonString = defaultJsonb.toJson(testValueQuoted);
         assertEquals("{\"bigDecValue\":9007199254740992}", jsonString);
 
-        jsonString = jsonb.toJson(testValueUnQuoted);
+        jsonString = defaultJsonb.toJson(testValueUnQuoted);
         assertEquals("{\"bigDecValue\":9007199254740991}", jsonString);
 
-        BigDecimalInNumber result = jsonb.fromJson("{\"bigDecValue\":9007199254740992}", BigDecimalInNumber.class);
+        BigDecimalInNumber result = defaultJsonb.fromJson("{\"bigDecValue\":9007199254740992}", BigDecimalInNumber.class);
         assertEquals(testValueQuoted.getBigDecValue(), result.getBigDecValue());
 
-        result = jsonb.fromJson("{\"bigDecValue\":9007199254740991}", BigDecimalInNumber.class);
+        result = defaultJsonb.fromJson("{\"bigDecValue\":9007199254740991}", BigDecimalInNumber.class);
         assertEquals(testValueUnQuoted.getBigDecValue(), result.getBigDecValue());
     }
 
     @Test
     public void testBigDecimalWrappedMarshalling() {
-        String jsonString = jsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.1000000000000001")));
+        String jsonString = defaultJsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.1000000000000001")));
         assertEquals("{\"value\":0.1000000000000001}", jsonString);
 
-        jsonString = jsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.10000000000000001")));
+        jsonString = defaultJsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.10000000000000001")));
         assertEquals("{\"value\":0.10000000000000001}", jsonString);
 
-        ScalarValueWrapper<BigDecimal> result = jsonb.fromJson("{\"value\":0.1000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
+        ScalarValueWrapper<BigDecimal> result = defaultJsonb.fromJson("{\"value\":0.1000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
         assertEquals(new BigDecimal("0.1000000000000001"), result.getValue());
 
-        result = jsonb.fromJson("{\"value\":0.10000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
+        result = defaultJsonb.fromJson("{\"value\":0.10000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
         assertEquals(new BigDecimal("0.10000000000000001"), result.getValue());
     }
 
     @Test
     public void testBigDecimalCastedToNumber() {
-        String jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.10000000000000001"); });
+        String jsonString = defaultJsonb.toJson(new Object() { public Number number = new BigDecimal("0.10000000000000001"); });
         assertEquals("{\"number\":0.10000000000000001}", jsonString);
 
-        jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.1000000000000001"); });
+        jsonString = defaultJsonb.toJson(new Object() { public Number number = new BigDecimal("0.1000000000000001"); });
         assertEquals("{\"number\":0.1000000000000001}", jsonString);
     }
 
     @Test
     public void testLongIEEE748() {
-
         // 9007199254740991L
         Long maxJsSafeValue = Double.valueOf(Math.pow(2, 53)).longValue() - 1;
         Long upperJsUnsafeValue = maxJsSafeValue + 1;
 
-        String json = jsonb.toJson(maxJsSafeValue);
+        String json = defaultJsonb.toJson(maxJsSafeValue);
         assertEquals("9007199254740991", json);
-        Long deserialized = jsonb.fromJson(json, Long.class);
+        Long deserialized = defaultJsonb.fromJson(json, Long.class);
         assertEquals(Long.valueOf("9007199254740991"), deserialized);
 
-        json = jsonb.toJson(upperJsUnsafeValue);
+        json = defaultJsonb.toJson(upperJsUnsafeValue);
         assertEquals("9007199254740992", json);
-        deserialized = jsonb.fromJson(json, Long.class);
+        deserialized = defaultJsonb.fromJson(json, Long.class);
         assertEquals(Long.valueOf("9007199254740992"), deserialized);
 
 
         Long minJsSafeValue = Math.negateExact(maxJsSafeValue);
         Long lowerJsUnsafeValue = minJsSafeValue - 1;
 
-        json = jsonb.toJson(minJsSafeValue);
+        json = defaultJsonb.toJson(minJsSafeValue);
         assertEquals("-9007199254740991", json);
-        deserialized = jsonb.fromJson(json, Long.class);
+        deserialized = defaultJsonb.fromJson(json, Long.class);
         assertEquals(Long.valueOf("-9007199254740991"), deserialized);
 
-        json = jsonb.toJson(lowerJsUnsafeValue);
+        json = defaultJsonb.toJson(lowerJsUnsafeValue);
         assertEquals("-9007199254740992", json);
-        deserialized = jsonb.fromJson(json, Long.class);
+        deserialized = defaultJsonb.fromJson(json, Long.class);
         assertEquals(Long.valueOf("-9007199254740992"), deserialized);
     }
 
@@ -223,11 +218,11 @@ public class NumberTest {
     
     @Test
     public void testSerializeInvalidDouble() {
-        shouldFail(() -> jsonb.toJson(Double.POSITIVE_INFINITY));
+        shouldFail(() -> defaultJsonb.toJson(Double.POSITIVE_INFINITY));
 
         NumberContainer obj = new NumberContainer();
         obj.doubleProp = Double.POSITIVE_INFINITY;
-        shouldFail(() -> jsonb.toJson(obj), msg -> msg.contains("doubleProp") && msg.contains("NumberContainer"));
+        shouldFail(() -> defaultJsonb.toJson(obj), msg -> msg.contains("doubleProp") && msg.contains("NumberContainer"));
     }
     
     
@@ -235,16 +230,15 @@ public class NumberTest {
     public void testSerializeInvalidDoubleCollection() {
         NumberContainer obj = new NumberContainer();
         obj.collectionProp = Collections.singleton(Double.POSITIVE_INFINITY);
-        shouldFail(() -> jsonb.toJson(obj),
-                msg -> msg.contains("collectionProp") && msg.contains("NumberContainer"));
+        shouldFail(() -> defaultJsonb.toJson(obj),
+                  msg -> msg.contains("collectionProp") && msg.contains("NumberContainer"));
     }
 
     @Test
     public void testSerializeInvalidDoubleMap() {
         NumberContainer obj = new NumberContainer();
         obj.mapProp = Collections.singletonMap("doubleKey", Double.POSITIVE_INFINITY);
-        shouldFail(() -> jsonb.toJson(obj),
-                msg -> msg.contains("mapProp") && msg.contains("NumberContainer"));
+        shouldFail(() -> defaultJsonb.toJson(obj),
+                  msg -> msg.contains("mapProp") && msg.contains("NumberContainer"));
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/NumberTest.java
@@ -14,12 +14,13 @@
 
 package org.eclipse.yasson.defaultmapping.basic;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.eclipse.yasson.Assertions.*;
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.basic.model.BigDecimalInNumber;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -29,9 +30,6 @@ import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 import javax.json.stream.JsonGenerator;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.StringWriter;
 import java.math.BigDecimal;
@@ -50,49 +48,49 @@ public class NumberTest {
     @Test
     public void testSerializeFloat() {
         final String json = jsonb.toJson(0.35f);
-        Assert.assertEquals("0.35", json);
+        assertEquals("0.35", json);
 
         Float result = jsonb.fromJson("0.35", Float.class);
-        Assert.assertEquals((Float) .35f, result);
+        assertEquals((Float) .35f, result);
     }
 
     @Test
     public void testBigDecimalMarshalling() {
         String jsonString = jsonb.toJson(new BigDecimal("0.10000000000000001"));
-        Assert.assertEquals("0.10000000000000001", jsonString);
+        assertEquals("0.10000000000000001", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("0.1000000000000001"));
-        Assert.assertEquals("0.1000000000000001", jsonString);
+        assertEquals("0.1000000000000001", jsonString);
 
         BigDecimal result = jsonb.fromJson("0.10000000000000001", BigDecimal.class);
-        Assert.assertEquals(new BigDecimal("0.10000000000000001"), result);
+        assertEquals(new BigDecimal("0.10000000000000001"), result);
 
         result = jsonb.fromJson("0.100000000000000001", BigDecimal.class);
-        Assert.assertEquals(new BigDecimal("0.100000000000000001"), result);
+        assertEquals(new BigDecimal("0.100000000000000001"), result);
     }
 
     @Test
     public void testBigDecimalIEEE748() {
         String jsonString = jsonb.toJson(new BigDecimal("9007199254740991"));
-        Assert.assertEquals("9007199254740991", jsonString);
+        assertEquals("9007199254740991", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("9007199254740992"));
-        Assert.assertEquals("9007199254740992", jsonString);
+        assertEquals("9007199254740992", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal("9007199254740991.1"));
-        Assert.assertEquals("9007199254740991.1", jsonString);
+        assertEquals("9007199254740991.1", jsonString);
 
         jsonString = jsonb.toJson(new BigDecimal(new BigInteger("1"), -400));
-        Assert.assertEquals(new BigDecimal(new BigInteger("1"), -400).toString(), jsonString);
+        assertEquals(new BigDecimal(new BigInteger("1"), -400).toString(), jsonString);
     }
 
     @Test
     public void testBigIntegerIEEE748() {
         String jsonString = jsonb.toJson(new BigInteger("9007199254740991"));
-        Assert.assertEquals("9007199254740991", jsonString);
+        assertEquals("9007199254740991", jsonString);
 
         jsonString = jsonb.toJson(new BigInteger("9007199254740992"));
-        Assert.assertEquals("9007199254740992", jsonString);
+        assertEquals("9007199254740992", jsonString);
     }
 
     @Test
@@ -100,40 +98,40 @@ public class NumberTest {
         BigDecimalInNumber testValueQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740992"));}};
         BigDecimalInNumber testValueUnQuoted = new BigDecimalInNumber() {{setBigDecValue(new BigDecimal("9007199254740991"));}};
         String jsonString = jsonb.toJson(testValueQuoted);
-        Assert.assertEquals("{\"bigDecValue\":9007199254740992}", jsonString);
+        assertEquals("{\"bigDecValue\":9007199254740992}", jsonString);
 
         jsonString = jsonb.toJson(testValueUnQuoted);
-        Assert.assertEquals("{\"bigDecValue\":9007199254740991}", jsonString);
+        assertEquals("{\"bigDecValue\":9007199254740991}", jsonString);
 
         BigDecimalInNumber result = jsonb.fromJson("{\"bigDecValue\":9007199254740992}", BigDecimalInNumber.class);
-        Assert.assertEquals(testValueQuoted.getBigDecValue(), result.getBigDecValue());
+        assertEquals(testValueQuoted.getBigDecValue(), result.getBigDecValue());
 
         result = jsonb.fromJson("{\"bigDecValue\":9007199254740991}", BigDecimalInNumber.class);
-        Assert.assertEquals(testValueUnQuoted.getBigDecValue(), result.getBigDecValue());
+        assertEquals(testValueUnQuoted.getBigDecValue(), result.getBigDecValue());
     }
 
     @Test
     public void testBigDecimalWrappedMarshalling() {
         String jsonString = jsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.1000000000000001")));
-        Assert.assertEquals("{\"value\":0.1000000000000001}", jsonString);
+        assertEquals("{\"value\":0.1000000000000001}", jsonString);
 
         jsonString = jsonb.toJson(new ScalarValueWrapper<>(new BigDecimal("0.10000000000000001")));
-        Assert.assertEquals("{\"value\":0.10000000000000001}", jsonString);
+        assertEquals("{\"value\":0.10000000000000001}", jsonString);
 
         ScalarValueWrapper<BigDecimal> result = jsonb.fromJson("{\"value\":0.1000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
-        Assert.assertEquals(new BigDecimal("0.1000000000000001"), result.getValue());
+        assertEquals(new BigDecimal("0.1000000000000001"), result.getValue());
 
         result = jsonb.fromJson("{\"value\":0.10000000000000001}", new TestTypeToken<ScalarValueWrapper<BigDecimal>>(){}.getType());
-        Assert.assertEquals(new BigDecimal("0.10000000000000001"), result.getValue());
+        assertEquals(new BigDecimal("0.10000000000000001"), result.getValue());
     }
 
     @Test
     public void testBigDecimalCastedToNumber() {
         String jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.10000000000000001"); });
-        Assert.assertEquals("{\"number\":0.10000000000000001}", jsonString);
+        assertEquals("{\"number\":0.10000000000000001}", jsonString);
 
         jsonString = jsonb.toJson(new Object() { public Number number = new BigDecimal("0.1000000000000001"); });
-        Assert.assertEquals("{\"number\":0.1000000000000001}", jsonString);
+        assertEquals("{\"number\":0.1000000000000001}", jsonString);
     }
 
     @Test
@@ -144,28 +142,28 @@ public class NumberTest {
         Long upperJsUnsafeValue = maxJsSafeValue + 1;
 
         String json = jsonb.toJson(maxJsSafeValue);
-        Assert.assertEquals("9007199254740991", json);
+        assertEquals("9007199254740991", json);
         Long deserialized = jsonb.fromJson(json, Long.class);
-        Assert.assertEquals(Long.valueOf("9007199254740991"), deserialized);
+        assertEquals(Long.valueOf("9007199254740991"), deserialized);
 
         json = jsonb.toJson(upperJsUnsafeValue);
-        Assert.assertEquals("9007199254740992", json);
+        assertEquals("9007199254740992", json);
         deserialized = jsonb.fromJson(json, Long.class);
-        Assert.assertEquals(Long.valueOf("9007199254740992"), deserialized);
+        assertEquals(Long.valueOf("9007199254740992"), deserialized);
 
 
         Long minJsSafeValue = Math.negateExact(maxJsSafeValue);
         Long lowerJsUnsafeValue = minJsSafeValue - 1;
 
         json = jsonb.toJson(minJsSafeValue);
-        Assert.assertEquals("-9007199254740991", json);
+        assertEquals("-9007199254740991", json);
         deserialized = jsonb.fromJson(json, Long.class);
-        Assert.assertEquals(Long.valueOf("-9007199254740991"), deserialized);
+        assertEquals(Long.valueOf("-9007199254740991"), deserialized);
 
         json = jsonb.toJson(lowerJsUnsafeValue);
-        Assert.assertEquals("-9007199254740992", json);
+        assertEquals("-9007199254740992", json);
         deserialized = jsonb.fromJson(json, Long.class);
-        Assert.assertEquals(Long.valueOf("-9007199254740992"), deserialized);
+        assertEquals(Long.valueOf("-9007199254740992"), deserialized);
     }
 
     /**
@@ -188,7 +186,7 @@ public class NumberTest {
         generator.writeEnd();
         generator.close();
 
-        Assert.assertEquals("{" +
+        assertEquals("{" +
                         "\"safeLongValue\":9007199254740991," +
                         "\"unsafeLongValue\":9223372036854775807," +
                         "\"safeBigDecimalValue\":10," +
@@ -209,7 +207,7 @@ public class NumberTest {
         writer.write(build);
         writer.close();
 
-        Assert.assertEquals("{" +
+        assertEquals("{" +
                 "\"safeLongValue\":9007199254740991," +
                 "\"unsafeLongValue\":9223372036854775807," +
                 "\"safeBigDecimalValue\":9007199254740991," +

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/PropertyMismatchTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/PropertyMismatchTest.java
@@ -11,13 +11,12 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.annotation.JsonbTransient;
 
 import org.jboss.weld.exceptions.IllegalStateException;
@@ -97,7 +96,7 @@ public class PropertyMismatchTest {
                                  "\"dataMap\": { \"foo\": \"bar\" }, " +
                                  "\"dataArray\": [\"foo\"], " +
                                  "\"data\": \"foo\" }";
-        CollectionGetterOnly collection = JsonbBuilder.create().fromJson(jsonCollection, CollectionGetterOnly.class);
+        CollectionGetterOnly collection = defaultJsonb.fromJson(jsonCollection, CollectionGetterOnly.class);
         // Don't need to verify resulting object (except that it is non-null)
         // because if any getters or ctors were called, we would get an ISE
         assertNotNull(collection);
@@ -109,7 +108,7 @@ public class PropertyMismatchTest {
     @Test
     public void testSetterOnly() {
         CollectionSetterOnly obj = new CollectionSetterOnly();
-        String json = JsonbBuilder.create().toJson(obj);
+        String json = defaultJsonb.toJson(obj);
         assertEquals("{}", json);
     }
     
@@ -138,11 +137,10 @@ public class PropertyMismatchTest {
         Instant now = Instant.now();
         obj.setFoo(now);
         
-        Jsonb jsonb = JsonbBuilder.create();
-        String json = jsonb.toJson(obj);
+        String json = defaultJsonb.toJson(obj);
         assertEquals("{\"foo\":" + now.toString().length() + "}", json);
         
-        PropertyTypeMismatch after = jsonb.fromJson("{\"foo\":\"" + now.toString() + "\"}", PropertyTypeMismatch.class);
+        PropertyTypeMismatch after = defaultJsonb.fromJson("{\"foo\":\"" + now.toString() + "\"}", PropertyTypeMismatch.class);
         assertEquals(obj.getFoo(), after.getFoo());
         assertEquals(obj.internalInstantProperty, after.internalInstantProperty);
     }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/PropertyMismatchTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/PropertyMismatchTest.java
@@ -9,8 +9,8 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -21,7 +21,6 @@ import javax.json.bind.JsonbBuilder;
 import javax.json.bind.annotation.JsonbTransient;
 
 import org.jboss.weld.exceptions.IllegalStateException;
-import org.junit.Test;
 
 /**
  * Tests to verify that read-only properties (properties with no field or setter)

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
@@ -2,6 +2,7 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.internal.JsonBindingBuilder;
 import org.eclipse.yasson.internal.properties.MessageKeys;
@@ -20,48 +21,46 @@ public class SingleValueTest {
 
     @Test
     public void testMarshallPrimitives() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
         // String
-        assertEquals("\"some_string\"", jsonb.toJson("some_string"));
+        assertEquals("\"some_string\"", bindingJsonb.toJson("some_string"));
 
         // Character
-        assertEquals("\"\uFFFF\"", jsonb.toJson('\uFFFF'));
+        assertEquals("\"\uFFFF\"", bindingJsonb.toJson('\uFFFF'));
 
         // Byte
-        assertEquals("1", jsonb.toJson((byte)1));
+        assertEquals("1", bindingJsonb.toJson((byte)1));
 
         // Short
-        assertEquals("1", jsonb.toJson((short)1));
+        assertEquals("1", bindingJsonb.toJson((short)1));
 
         // Integer
-        assertEquals("1", jsonb.toJson(1));
+        assertEquals("1", bindingJsonb.toJson(1));
 
         // Long
-        assertEquals("5", jsonb.toJson(5L));
+        assertEquals("5", bindingJsonb.toJson(5L));
 
         // Float
-        assertEquals("1.2", jsonb.toJson(1.2f));
+        assertEquals("1.2", bindingJsonb.toJson(1.2f));
 
         // Double
-        assertEquals("1.2", jsonb.toJson(1.2));
+        assertEquals("1.2", bindingJsonb.toJson(1.2));
 
         // BigInteger
-        assertEquals("1", jsonb.toJson(new BigInteger("1")));
+        assertEquals("1", bindingJsonb.toJson(new BigInteger("1")));
 
         // BigDecimal
-        assertEquals("1.2", jsonb.toJson(new BigDecimal("1.2")));
+        assertEquals("1.2", bindingJsonb.toJson(new BigDecimal("1.2")));
 
         // Number
-        assertEquals("1.2", jsonb.toJson(1.2));
+        assertEquals("1.2", bindingJsonb.toJson(1.2));
 
         // Boolean true
-        assertEquals("true", jsonb.toJson(true));
+        assertEquals("true", bindingJsonb.toJson(true));
 
         // Boolean false
-        assertEquals("false", jsonb.toJson(false));
+        assertEquals("false", bindingJsonb.toJson(false));
 
-        assertEquals("1", jsonb.toJson(1));
+        assertEquals("1", bindingJsonb.toJson(1));
 
         // null
         //assertEquals("null", jsonb.toJson(null));
@@ -75,9 +74,9 @@ public class SingleValueTest {
         jsonb = (new JsonBindingBuilder().withConfig(new JsonbConfig().withStrictIJSON(true))).build();
         try {
             jsonb.toJson(5);
-            Assert.fail();
+            fail();
         } catch (JsonbException exception){
-            Assert.assertEquals(Messages.getMessage(MessageKeys.IJSON_ENABLED_SINGLE_VALUE), exception.getMessage());
+            assertEquals(Messages.getMessage(MessageKeys.IJSON_ENABLED_SINGLE_VALUE), exception.getMessage());
         }
     }
 

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
@@ -68,10 +68,9 @@ public class SingleValueTest {
 
     @Test
     public void testSingleValue() {
-        Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("5", jsonb.toJson(5));
+        assertEquals("5", bindingJsonb.toJson(5));
 
-        jsonb = (new JsonBindingBuilder().withConfig(new JsonbConfig().withStrictIJSON(true))).build();
+        Jsonb jsonb = new JsonBindingBuilder().withConfig(new JsonbConfig().withStrictIJSON(true)).build();
         try {
             jsonb.toJson(5);
             fail();
@@ -79,5 +78,4 @@ public class SingleValueTest {
             assertEquals(Messages.getMessage(MessageKeys.IJSON_ENABLED_SINGLE_VALUE), exception.getMessage());
         }
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/SingleValueTest.java
@@ -1,18 +1,17 @@
 package org.eclipse.yasson.defaultmapping.basic;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.JsonBindingBuilder;
 import org.eclipse.yasson.internal.properties.MessageKeys;
 import org.eclipse.yasson.internal.properties.Messages;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.JsonbException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author David Kral

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
@@ -14,8 +14,7 @@ package org.eclipse.yasson.defaultmapping.basic;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import javax.json.bind.JsonbBuilder;
+import static org.eclipse.yasson.Jsonbs.*;
 
 public class UnqualifiedPropertiesTest {
 	
@@ -43,12 +42,11 @@ public class UnqualifiedPropertiesTest {
 	
 	@Test
 	public void testGetWithArgs() {
-	    assertEquals("{\"foo\":\"foo\",\"now\":0}", JsonbBuilder.create().toJson(new Widget()));
+	    assertEquals("{\"foo\":\"foo\",\"now\":0}", defaultJsonb.toJson(new Widget()));
 	}
 	
 	@Test
 	public void testSetWithNoArgs() {
-		assertEquals("{\"foo\":\"foo\",\"now\":1511576115722}", JsonbBuilder.create().toJson(new Widget().setNow()));
+		assertEquals("{\"foo\":\"foo\",\"now\":1511576115722}", defaultJsonb.toJson(new Widget().setNow()));
 	}
-	
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/basic/UnqualifiedPropertiesTest.java
@@ -12,11 +12,10 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.basic;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.JsonbBuilder;
-
-import org.junit.Test;
 
 public class UnqualifiedPropertiesTest {
 	

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
@@ -13,10 +13,10 @@
 
 package org.eclipse.yasson.defaultmapping.collections;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
@@ -15,12 +15,10 @@ package org.eclipse.yasson.defaultmapping.collections;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbConfig;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,13 +30,6 @@ import java.util.Map;
  */
 public class ArrayTest {
 
-    private Jsonb jsonb;
-
-    @BeforeAll
-    public void before() {
-        jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
-    }
-
     @Test
     public void testStringArray() {
         String[] stringArray = new String[3];
@@ -48,9 +39,9 @@ public class ArrayTest {
 
         String expected = "[\"first\",\"second\",\"third\"]";
 
-        assertEquals(expected, jsonb.toJson(stringArray));
+        assertEquals(expected, nullableJsonb.toJson(stringArray));
 
-        String[] result = jsonb.fromJson(expected, stringArray.getClass());
+        String[] result = nullableJsonb.fromJson(expected, stringArray.getClass());
         assertEquals("first", result[0]);
         assertEquals("second", result[1]);
         assertEquals("third", result[2]);
@@ -64,8 +55,8 @@ public class ArrayTest {
 
         String expected = "[{\"field\":\"first\"},{\"field\":\"second\"}]";
 
-        assertEquals(expected, jsonb.toJson(objectArray));
-        Object[] result = jsonb.fromJson(expected, objectArray.getClass());
+        assertEquals(expected, nullableJsonb.toJson(objectArray));
+        Object[] result = nullableJsonb.fromJson(expected, objectArray.getClass());
         assertEquals(HashMap.class, result[0].getClass());
         assertEquals(HashMap.class, result[1].getClass());
         assertEquals("first", ((Map) result[0]).get("field"));
@@ -82,8 +73,8 @@ public class ArrayTest {
         listOfArrays.add(stringArray);
 
         String expected = "[[\"first\",\"second\"],[\"first\",\"second\"]]";
-        assertEquals(expected, jsonb.toJson(listOfArrays));
-        List<String[]> result = jsonb.fromJson(expected, new TestTypeToken<ArrayList<String[]>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(listOfArrays));
+        List<String[]> result = nullableJsonb.fromJson(expected, new TestTypeToken<ArrayList<String[]>>(){}.getType());
         assertEquals("first", result.get(0)[0]);
         assertEquals("second", result.get(0)[1]);
         assertEquals("first", result.get(1)[0]);
@@ -98,8 +89,8 @@ public class ArrayTest {
         multi[1][0] = "[1],[0]";
         multi[1][1] = "[1],[1]";
         String expected = "[[\"[0],[0]\",\"[0],[1]\"],[\"[1],[0]\",\"[1],[1]\"]]";
-        assertEquals(expected, jsonb.toJson(multi));
-        String[][] result = jsonb.fromJson(expected, multi.getClass());
+        assertEquals(expected, nullableJsonb.toJson(multi));
+        String[][] result = nullableJsonb.fromJson(expected, multi.getClass());
         assertEquals("[0],[0]", result[0][0]);
         assertEquals("[0],[1]", result[0][1]);
         assertEquals("[1],[0]", result[1][0]);
@@ -109,7 +100,7 @@ public class ArrayTest {
     @Test
     public void testDeserializeJsonArrayIntoObject() {
         String json = "[\"first\",\"second\",\"third\"]";
-        Object result = jsonb.fromJson(json, Object.class);
+        Object result = nullableJsonb.fromJson(json, Object.class);
         assertTrue(result instanceof List);
         assertEquals("first", ((List)result).get(0));
         assertEquals("second", ((List)result).get(1));
@@ -119,7 +110,7 @@ public class ArrayTest {
     @Test
     public void testDeserializeJsonObjectIntoListOfMaps() {
         String json = "[{\"first\":1,\"second\":10}]";
-        Object result = jsonb.fromJson(json, List.class);
+        Object result = nullableJsonb.fromJson(json, List.class);
         assertTrue(result instanceof List);
         assertEquals(BigDecimal.ONE, ((Map) ((List) result).get(0)).get("first"));
         assertEquals(BigDecimal.TEN, ((Map) ((List) result).get(0)).get("second"));
@@ -133,8 +124,8 @@ public class ArrayTest {
         strings[1] = "one";
         arrayValueMap.put("first", strings);
         String expected = "{\"first\":[\"zero\",\"one\"]}";
-        assertEquals(expected, jsonb.toJson(arrayValueMap));
-        Map<String, String[]> result = jsonb.fromJson(expected, new TestTypeToken<HashMap<String, String[]>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(arrayValueMap));
+        Map<String, String[]> result = nullableJsonb.fromJson(expected, new TestTypeToken<HashMap<String, String[]>>(){}.getType());
         assertEquals("zero", result.get("first")[0]);
         assertEquals("one", result.get("first")[1]);
     }
@@ -143,63 +134,63 @@ public class ArrayTest {
     public void testArrayOfNulls() {
         String[] nulls = new String[2];
         String expected = "[null,null]";
-        assertEquals(expected, jsonb.toJson(nulls));
-        String[] result = jsonb.fromJson(expected, nulls.getClass());
+        assertEquals(expected, nullableJsonb.toJson(nulls));
+        String[] result = nullableJsonb.fromJson(expected, nulls.getClass());
         assertTrue(result.length == 2);
         assertNull(result[0]);
         assertNull(result[1]);
 
         Integer ints[] = new Integer[2];
-        assertEquals(expected, jsonb.toJson(ints));
+        assertEquals(expected, nullableJsonb.toJson(ints));
     }
 
     @Test
     public void testByteArray() {
         byte[] byteArr = {-128, 127};
-        assertEquals("[-128,127]", jsonb.toJson(byteArr));
-        assertArrayEquals(byteArr, jsonb.fromJson("[-128, 127]", byte[].class));
+        assertEquals("[-128,127]", nullableJsonb.toJson(byteArr));
+        assertArrayEquals(byteArr, nullableJsonb.fromJson("[-128, 127]", byte[].class));
     }
 
     @Test
     public void testCharArray() {
         char[] charArr = {'a', 'b', 'c'};
-        assertEquals("[\"a\",\"b\",\"c\"]", jsonb.toJson(charArr));
-        assertArrayEquals(charArr, jsonb.fromJson("[\"a\",\"b\",\"c\"]", char[].class));
+        assertEquals("[\"a\",\"b\",\"c\"]", nullableJsonb.toJson(charArr));
+        assertArrayEquals(charArr, nullableJsonb.fromJson("[\"a\",\"b\",\"c\"]", char[].class));
     }
 
     @Test
     public void testShortArray() {
         short[] shortArr = {-128, 127};
-        assertEquals("[-128,127]", jsonb.toJson(shortArr));
-        assertArrayEquals(shortArr, jsonb.fromJson("[-128, 127]", short[].class));
+        assertEquals("[-128,127]", nullableJsonb.toJson(shortArr));
+        assertArrayEquals(shortArr, nullableJsonb.fromJson("[-128, 127]", short[].class));
     }
 
     @Test
     public void testIntArray() {
         int[] intArr = {-128, 127};
-        assertEquals("[-128,127]", jsonb.toJson(intArr));
-        assertArrayEquals(intArr, jsonb.fromJson("[-128, 127]", int[].class));
+        assertEquals("[-128,127]", nullableJsonb.toJson(intArr));
+        assertArrayEquals(intArr, nullableJsonb.fromJson("[-128, 127]", int[].class));
     }
 
     @Test
     public void testLongArray() {
         long[] longArr = {-128, 127};
-        assertEquals("[-128,127]", jsonb.toJson(longArr));
-        assertArrayEquals(longArr, jsonb.fromJson("[-128, 127]", long[].class));
+        assertEquals("[-128,127]", nullableJsonb.toJson(longArr));
+        assertArrayEquals(longArr, nullableJsonb.fromJson("[-128, 127]", long[].class));
     }
 
     @Test
     public void testFloatArray() {
         float[] floatArr = {-128, 127};
-        assertEquals("[-128.0,127.0]", jsonb.toJson(floatArr));
-        assertArrayEquals(floatArr, jsonb.fromJson("[-128.0, 127.0]", float[].class), 0f);
+        assertEquals("[-128.0,127.0]", nullableJsonb.toJson(floatArr));
+        assertArrayEquals(floatArr, nullableJsonb.fromJson("[-128.0, 127.0]", float[].class), 0f);
     }
 
     @Test
     public void testDoubleArray() {
         double[] doubleArr = {-128, 127};
-        assertEquals("[-128.0,127.0]", jsonb.toJson(doubleArr));
-        assertArrayEquals(doubleArr, jsonb.fromJson("[-128.0, 127.0]", double[].class), 0d);
+        assertEquals("[-128.0,127.0]", nullableJsonb.toJson(doubleArr));
+        assertArrayEquals(doubleArr, nullableJsonb.fromJson("[-128.0, 127.0]", double[].class), 0d);
     }
 
     public static class KeyValue {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/ArrayTest.java
@@ -34,7 +34,7 @@ public class ArrayTest {
 
     private Jsonb jsonb;
 
-    @Before
+    @BeforeAll
     public void before() {
         jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
     }
@@ -150,7 +150,7 @@ public class ArrayTest {
         assertNull(result[1]);
 
         Integer ints[] = new Integer[2];
-        Assert.assertEquals(expected, jsonb.toJson(ints));
+        assertEquals(expected, jsonb.toJson(ints));
     }
 
     @Test

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.Circle;
-import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbConfig;
@@ -34,7 +33,7 @@ public class CollectionsTest {
 
     private Jsonb jsonb;
 
-    @Before
+    @BeforeAll
     public void before() {
         jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
     }
@@ -249,12 +248,12 @@ public class CollectionsTest {
         map.put("first", "abc");
         map.put("second", "def");
         final String json = jsonb.toJson(map);
-        Assert.assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
+        assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
 
         NavigableMap<String, String> result = jsonb.fromJson(json, new TestTypeToken<NavigableMap<String, String>>() {}.getType());
-        Assert.assertEquals(TreeMap.class, result.getClass());
-        Assert.assertEquals("abc", result.get("first"));
-        Assert.assertEquals("def", result.get("second"));
+        assertEquals(TreeMap.class, result.getClass());
+        assertEquals("abc", result.get("first"));
+        assertEquals("def", result.get("second"));
     }
 
     @Test
@@ -263,12 +262,12 @@ public class CollectionsTest {
         map.put("first", "abc");
         map.put("second", "def");
         final String json = jsonb.toJson(map);
-        Assert.assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
+        assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
 
         SortedMap<String, String> result = jsonb.fromJson(json, new TestTypeToken<SortedMap<String, String>>() {}.getType());
-        Assert.assertEquals(TreeMap.class, result.getClass());
-        Assert.assertEquals("abc", result.get("first"));
-        Assert.assertEquals("def", result.get("second"));
+        assertEquals(TreeMap.class, result.getClass());
+        assertEquals("abc", result.get("first"));
+        assertEquals("def", result.get("second"));
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
@@ -12,21 +12,18 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.collections;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.Circle;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Default mapping arrays/collections/enums tests.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/collections/CollectionsTest.java
@@ -14,13 +14,11 @@ package org.eclipse.yasson.defaultmapping.collections;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.Circle;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbConfig;
-import javax.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.util.*;
 
@@ -31,42 +29,31 @@ import java.util.*;
  */
 public class CollectionsTest {
 
-    private Jsonb jsonb;
-
-    @BeforeAll
-    public void before() {
-        jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
-    }
-
     @Test
     public void testMarshallCollection() {
-
         final Collection<Integer> collection = Arrays.asList(1, 2, 3);
-        assertEquals("[1,2,3]", jsonb.toJson(collection));
+        assertEquals("[1,2,3]", nullableJsonb.toJson(collection));
     }
 
     @Test
     public void testMarshallMap() {
-
         Map<String, Integer> stringIntegerMap = new LinkedHashMap<>();
         stringIntegerMap.put("1",1);
         stringIntegerMap.put("2",2);
         stringIntegerMap.put("3",3);
 
-        assertEquals("{\"1\":1,\"2\":2,\"3\":3}", jsonb.toJson(stringIntegerMap));
-
-        assertEquals(stringIntegerMap, jsonb.fromJson("{\"1\":1,\"2\":2,\"3\":3}", new LinkedHashMap<String, Integer>(){}.getClass().getGenericSuperclass()));
+        assertEquals("{\"1\":1,\"2\":2,\"3\":3}", nullableJsonb.toJson(stringIntegerMap));
+        assertEquals(stringIntegerMap, nullableJsonb.fromJson("{\"1\":1,\"2\":2,\"3\":3}", new LinkedHashMap<String, Integer>(){}.getClass().getGenericSuperclass()));
     }
 
     @Test
     public void testMarshallMapWithNulls() {
-
         Map<String, String> mapWithNulls = new LinkedHashMap<>();
         mapWithNulls.put("key1",null);
         mapWithNulls.put("key2",null);
         mapWithNulls.put("key3",null);
 
-        assertEquals("{\"key1\":null,\"key2\":null,\"key3\":null}", jsonb.toJson(mapWithNulls));
+        assertEquals("{\"key1\":null,\"key2\":null,\"key3\":null}", nullableJsonb.toJson(mapWithNulls));
     }
 
     @Test
@@ -76,34 +63,37 @@ public class CollectionsTest {
         numberList.add(2f);
         numberList.add(10);
 
-        String result = jsonb.toJson(numberList, new TestTypeToken<List<Number>>(){}.getType());
+        String result = nullableJsonb.toJson(numberList, new TestTypeToken<List<Number>>(){}.getType());
     }
 
     @Test
     public void testListOfListsOfStrings() {
-
         List<List<String>> listOfListsOfStrings = new ArrayList<>();
-        for(int i=0; i<10; i++) {
+        
+        for(int i = 0; i < 10; i++) {
             List<String> stringList = new ArrayList<>();
             stringList.add("first");
             stringList.add("second");
             stringList.add("third");
             listOfListsOfStrings.add(stringList);
         }
+        
         final String expected = "[[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"],[\"first\",\"second\",\"third\"]]";
-        assertEquals(expected, jsonb.toJson(listOfListsOfStrings));
-        assertEquals(listOfListsOfStrings, jsonb.fromJson(expected, new ArrayList<List<String>>(){}.getClass().getGenericSuperclass()));
+        assertEquals(expected, nullableJsonb.toJson(listOfListsOfStrings));
+        assertEquals(listOfListsOfStrings, nullableJsonb.fromJson(expected, new ArrayList<List<String>>(){}.getClass().getGenericSuperclass()));
     }
 
     @Test
     public void listOfMapsOfListsOfMaps() {
-
         List<Map<String, List<Map<String, Integer>>>> listOfMapsOfListsOfMaps = new ArrayList<>();
-        for(int i=0; i<3; i++) {
+        
+        for(int i = 0; i < 3; i++) {
             Map<String, List<Map<String, Integer>>> mapOfListsOfMap = new HashMap<>();
-            for(int j=0; j<3; j++) {
+            
+            for(int j = 0; j < 3; j++) {
                 List<Map<String, Integer>> listOfMaps = new ArrayList<>();
-                for(int k=0; k<3; k++) {
+                
+                for(int k = 0; k < 3; k++) {
                     Map<String, Integer> stringIntegerMap = new HashMap<>();
                     stringIntegerMap.put("first", 1);
                     stringIntegerMap.put("second", 2);
@@ -114,9 +104,10 @@ public class CollectionsTest {
             }
             listOfMapsOfListsOfMaps.add(mapOfListsOfMap);
         }
+        
         String expected = "[{\"0\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"1\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"2\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}]},{\"0\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"1\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"2\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}]},{\"0\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"1\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}],\"2\":[{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2},{\"third\":3,\"first\":1,\"second\":2}]}]";
-        assertEquals(expected, jsonb.toJson(listOfMapsOfListsOfMaps));
-        ArrayList<Map<String, List<Map<String, Integer>>>> result = jsonb.fromJson(expected, new TestTypeToken<ArrayList<Map<String, List<Map<String, Integer>>>>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(listOfMapsOfListsOfMaps));
+        ArrayList<Map<String, List<Map<String, Integer>>>> result = nullableJsonb.fromJson(expected, new TestTypeToken<ArrayList<Map<String, List<Map<String, Integer>>>>>(){}.getType());
         assertEquals(listOfMapsOfListsOfMaps, result);
     }
 
@@ -126,8 +117,8 @@ public class CollectionsTest {
         deque.add("dequeueFirst");
         deque.add("dequeueSecond");
         String expected = "[\"dequeueFirst\",\"dequeueSecond\"]";
-        assertEquals(expected, jsonb.toJson(deque));
-        Deque<String> dequeueResult = jsonb.fromJson(expected, new TestTypeToken<ArrayDeque<String>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(deque));
+        Deque<String> dequeueResult = nullableJsonb.fromJson(expected, new TestTypeToken<ArrayDeque<String>>(){}.getType());
         assertEquals("dequeueFirst", dequeueResult.getFirst());
         assertEquals("dequeueSecond", dequeueResult.getLast());
 
@@ -135,8 +126,8 @@ public class CollectionsTest {
         linkedHashSet.add("setFirst");
         linkedHashSet.add("setSecond");
         expected = "[\"setFirst\",\"setSecond\"]";
-        assertEquals(expected, jsonb.toJson(linkedHashSet));
-        LinkedHashSet<String> linkedHashSetResult = jsonb.fromJson(expected, new TestTypeToken<LinkedHashSet<String>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(linkedHashSet));
+        LinkedHashSet<String> linkedHashSetResult = nullableJsonb.fromJson(expected, new TestTypeToken<LinkedHashSet<String>>(){}.getType());
         Iterator<String> iterator = linkedHashSetResult.iterator();
         assertEquals("setFirst", iterator.next());
         assertEquals("setSecond", iterator.next());
@@ -145,18 +136,16 @@ public class CollectionsTest {
         linkedList.add("listFirst");
         linkedList.add("listSecond");
         expected = "[\"listFirst\",\"listSecond\"]";
-        assertEquals(expected, jsonb.toJson(linkedList));
-        LinkedList<String> linkedListResult = jsonb.fromJson(expected, new TestTypeToken<LinkedList<String>>(){}.getType());
+        assertEquals(expected, nullableJsonb.toJson(linkedList));
+        LinkedList<String> linkedListResult = nullableJsonb.fromJson(expected, new TestTypeToken<LinkedList<String>>(){}.getType());
         iterator = linkedListResult.iterator();
         assertEquals("listFirst", iterator.next());
         assertEquals("listSecond", iterator.next());
     }
 
-
     @Test
     @SuppressWarnings("unchecked")
     public void testMarshallArray() {
-
         //support of arrays of types that JSON Binding is able to serialize
         //Byte[], Short[], Integer[] Long[], Float[], Double[], BigInteger[], BigDecimal[], Number[]
         //Object[], JsonArray[], JsonObject[], JsonStructure[]
@@ -167,27 +156,26 @@ public class CollectionsTest {
         //enum, EnumSet, EnumMap
         //support of multidimensional arrays
 
-
         final Byte[] byteArray = {1, 2, 3};
-        assertEquals("[1,2,3]", jsonb.toJson(byteArray));
+        assertEquals("[1,2,3]", nullableJsonb.toJson(byteArray));
 
         final Integer[] integerArray = {1, 2, 3};
-        assertEquals("[1,2,3]", jsonb.toJson(integerArray));
+        assertEquals("[1,2,3]", nullableJsonb.toJson(integerArray));
 
         final String[] stringArray = {"first", "second", "third"};
-        assertEquals("[\"first\",\"second\",\"third\"]", jsonb.toJson(stringArray));
+        assertEquals("[\"first\",\"second\",\"third\"]", nullableJsonb.toJson(stringArray));
 
         Character[] charArr = {'a', 'b', 'c'};
-        assertEquals("[\"a\",\"b\",\"c\"]", jsonb.toJson(charArr));
+        assertEquals("[\"a\",\"b\",\"c\"]", nullableJsonb.toJson(charArr));
 
         final byte[] bytePrimitivesArray = {1, 2, 3};
-        assertEquals("[1,2,3]", jsonb.toJson(bytePrimitivesArray));
+        assertEquals("[1,2,3]", nullableJsonb.toJson(bytePrimitivesArray));
 
         final int[] intArray = {1, 2, 3};
-        assertEquals("[1,2,3]", jsonb.toJson(intArray));
+        assertEquals("[1,2,3]", nullableJsonb.toJson(intArray));
 
         final String[][] stringMultiArray = {{"first", "second"},{"third", "fourth"}};
-        assertEquals("[[\"first\",\"second\"],[\"third\",\"fourth\"]]", jsonb.toJson(stringMultiArray));
+        assertEquals("[[\"first\",\"second\"],[\"third\",\"fourth\"]]", nullableJsonb.toJson(stringMultiArray));
 
         final Map<String, Object>[][] mapMultiArray = new LinkedHashMap[2][2];
         mapMultiArray[0][0] = new LinkedHashMap<>(1);
@@ -199,27 +187,25 @@ public class CollectionsTest {
         mapMultiArray[1][1] = new LinkedHashMap<>(1);
         mapMultiArray[1][1].put("1", 1);
 
-        assertEquals("[[{\"0\":0},{\"0\":1}],[{\"1\":0},{\"1\":1}]]", jsonb.toJson(mapMultiArray));
+        assertEquals("[[{\"0\":0},{\"0\":1}],[{\"1\":0},{\"1\":1}]]", nullableJsonb.toJson(mapMultiArray));
     }
 
     @Test
     public void testMarshallEnumSet() {
-
         final EnumSet<Language> languageEnumSet = EnumSet.of(Language.Czech, Language.Slovak);
 
-        final String result = jsonb.toJson(languageEnumSet);
+        final String result = nullableJsonb.toJson(languageEnumSet);
         assertTrue("[\"Czech\",\"Slovak\"]".equals(result) || "[\"Slovak\",\"Czech\"]".equals(result));
-        assertEquals(languageEnumSet, jsonb.fromJson(result, new TestTypeToken<EnumSet<Language>>() {}.getType()));
+        assertEquals(languageEnumSet, nullableJsonb.fromJson(result, new TestTypeToken<EnumSet<Language>>() {}.getType()));
     }
 
     @Test
     public void testMarshallEnumMap() {
-
         final EnumMap<Language, String> languageEnumMap = new EnumMap<>(Language.class);
         languageEnumMap.put(Language.Russian, "ru");
         languageEnumMap.put(Language.English, "en");
 
-        final String result = jsonb.toJson(languageEnumMap);
+        final String result = nullableJsonb.toJson(languageEnumMap);
         assertTrue("{\"Russian\":\"ru\",\"English\":\"en\"}".equals(result) ||
                 "{\"English\":\"en\",\"Russian\":\"ru\"}".equals(result));
     }
@@ -235,8 +221,8 @@ public class CollectionsTest {
         rawList.add(circle);
 
         String expected = "[\"first\",{\"area\":1.0,\"radius\":2.0}]";
-        assertEquals(expected, jsonb.toJson(rawList));
-        List result = jsonb.fromJson(expected, List.class);
+        assertEquals(expected, nullableJsonb.toJson(rawList));
+        List result = nullableJsonb.fromJson(expected, List.class);
         assertEquals("first", result.get(0));
         assertEquals(new BigDecimal("2.0"), ((Map)result.get(1)).get("radius"));
         assertEquals(new BigDecimal("1.0"), ((Map)result.get(1)).get("area"));
@@ -247,10 +233,10 @@ public class CollectionsTest {
         NavigableMap<String, String> map = new TreeMap<>();
         map.put("first", "abc");
         map.put("second", "def");
-        final String json = jsonb.toJson(map);
+        final String json = nullableJsonb.toJson(map);
         assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
 
-        NavigableMap<String, String> result = jsonb.fromJson(json, new TestTypeToken<NavigableMap<String, String>>() {}.getType());
+        NavigableMap<String, String> result = nullableJsonb.fromJson(json, new TestTypeToken<NavigableMap<String, String>>() {}.getType());
         assertEquals(TreeMap.class, result.getClass());
         assertEquals("abc", result.get("first"));
         assertEquals("def", result.get("second"));
@@ -261,13 +247,12 @@ public class CollectionsTest {
         SortedMap<String, String> map = new TreeMap<>();
         map.put("first", "abc");
         map.put("second", "def");
-        final String json = jsonb.toJson(map);
+        final String json = nullableJsonb.toJson(map);
         assertEquals("{\"first\":\"abc\",\"second\":\"def\"}", json);
 
-        SortedMap<String, String> result = jsonb.fromJson(json, new TestTypeToken<SortedMap<String, String>>() {}.getType());
+        SortedMap<String, String> result = nullableJsonb.fromJson(json, new TestTypeToken<SortedMap<String, String>>() {}.getType());
         assertEquals(TreeMap.class, result.getClass());
         assertEquals("abc", result.get("first"));
         assertEquals("def", result.get("second"));
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -14,6 +14,7 @@ package org.eclipse.yasson.defaultmapping.dates;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.dates.model.CalendarPojo;
@@ -74,9 +75,6 @@ import java.util.TimeZone;
  * @author Dmitry Kornilov
  */
 public class DatesTest {
-
-    private final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
     private static LocalDate localDate = LocalDate.of(2018, 1, 31);
 
     @SuppressWarnings("serial")
@@ -97,46 +95,38 @@ public class DatesTest {
     public void testSqlTimestamp() {
         Timestamp expectedTimestamp = Timestamp.from(Instant.now());
 
-        Jsonb jsonb = new JsonBindingBuilder().build();
-        String json = jsonb.toJson(expectedTimestamp);
+        String json = bindingJsonb.toJson(expectedTimestamp);
 
-        Timestamp timestamp = jsonb.fromJson(json, Timestamp.class);
+        Timestamp timestamp = bindingJsonb.fromJson(json, Timestamp.class);
         assertEquals(expectedTimestamp, timestamp);
     }
 
     @Test
     public void testMarshallSqlDate() {
-        Jsonb jsonb = new JsonBindingBuilder().build();
-        String jsonString = jsonb.toJson(new SqlDateObj());
-        Assert.assertEquals("{\"sqlDate\":\"2018-01-31Z\",\"utilDate\":\"2018-01-31Z\"}", jsonString);
+        String jsonString = bindingJsonb.toJson(new SqlDateObj());
+        assertEquals("{\"sqlDate\":\"2018-01-31Z\",\"utilDate\":\"2018-01-31Z\"}", jsonString);
     }
 
     @Test
     public void testUnmarshallSqlDate() {
-        JsonBindingBuilder builder = new JsonBindingBuilder();
-        Jsonb json = builder.build();
-        SqlDateObj result = json.fromJson("{\"sqlDate\":\"2018-01-31Z\",\"utilDate\":\"2018-01-31Z\"}", SqlDateObj.class);
+        SqlDateObj result = bindingJsonb.fromJson("{\"sqlDate\":\"2018-01-31Z\",\"utilDate\":\"2018-01-31Z\"}", SqlDateObj.class);
         long expectedUtcMillis = localDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli();
-        Assert.assertEquals(new java.sql.Date(expectedUtcMillis), result.sqlDate);
-        Assert.assertEquals(new java.sql.Date(expectedUtcMillis), result.utilDate);
+        assertEquals(new java.sql.Date(expectedUtcMillis), result.sqlDate);
+        assertEquals(new java.sql.Date(expectedUtcMillis), result.utilDate);
     }
 
     @Test
     public void testMarshallLocalDate() {
-        JsonBindingBuilder builder = new JsonBindingBuilder();
-        Jsonb json = builder.build();
-        String jsonString = json.toJson(new LocalDateObj());
+        String jsonString = bindingJsonb.toJson(new LocalDateObj());
         if (jsonString.contains("T")) {
-            Assert.fail("JSON contains time for a non Date that doesn't include time");
+            fail("JSON contains time for a non Date that doesn't include time");
         }
     }
 
     @Test
     public void testUnmarshallLocalDate() {
-        JsonBindingBuilder builder = new JsonBindingBuilder();
-        Jsonb json = builder.build();
-        LocalDateObj localDateObj = json.fromJson("{\"date\":\"2018-01-31\"}", LocalDateObj.class);
-        Assert.assertEquals(localDate, localDateObj.date);
+        LocalDateObj localDateObj = bindingJsonb.fromJson("{\"date\":\"2018-01-31\"}", LocalDateObj.class);
+        assertEquals(localDate, localDateObj.date);
     }
 
     @Test
@@ -154,9 +144,9 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-03-04T00:00:00Z[UTC]\"," +
                 "\"millisFormatted\":\"" + parsedDate.getTime()+ "\"," +
                 "\"customDate\":\"00:00:00 | 04-03-2015\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final DatePojo result = jsonb.fromJson(expected, DatePojo.class);
+        final DatePojo result = bindingJsonb.fromJson(expected, DatePojo.class);
         assertEquals(parsedDate, result.customDate);
         assertEquals(parsedDate, result.defaultFormatted);
         assertEquals(parsedDate, result.millisFormatted);
@@ -169,7 +159,7 @@ public class DatesTest {
         final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
     	
     	String jsonDateWithZone = "{\"dateWithZone\":\"2018-11-02T00:00:00+01:00\"}";
-    	final DateWithZonePojo result = jsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
+    	final DateWithZonePojo result = bindingJsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
     	
     	assertEquals(parsedDate, result.dateWithZone);
     }
@@ -181,7 +171,7 @@ public class DatesTest {
         final Date parsedDate = sdf.parse("2018-11-02T00:00:00+01:00");
     	
     	String jsonDateWithZone = "{\"dateWithZone\":\"2018-11-02T00:00:00+01:00[Europe/Berlin]\"}";
-    	final DateWithZonePojo result = jsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
+    	final DateWithZonePojo result = bindingJsonb.fromJson(jsonDateWithZone, DateWithZonePojo.class);
     	
     	assertEquals(parsedDate, result.dateWithZone);
     }
@@ -203,10 +193,10 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-04-03T11:11:10+02:00[Europe/Prague]\"," +
                 "\"millisFormatted\":\"1428052270000\"," +
                 "\"customCalendar\":\"11:11:10 | 03-04-2015, +0200\"}";
-        assertEquals(expected, jsonb.toJson(calendarPojo));
+        assertEquals(expected, bindingJsonb.toJson(calendarPojo));
 
         // marshal to ISO_DATE_TIME
-        final CalendarPojo result = jsonb.fromJson(expected, CalendarPojo.class);
+        final CalendarPojo result = bindingJsonb.fromJson(expected, CalendarPojo.class);
         assertEquals(timeCalendar.getTime(), result.customCalendar.getTime());
         assertEquals(timeCalendar.getTime(), result.millisFormatted.getTime());
         assertEquals(timeCalendar.getTime(), result.defaultFormatted.getTime());
@@ -214,14 +204,14 @@ public class DatesTest {
 
     @Test
     public void testCalendarWithoutTime() {
-        ScalarValueWrapper<Calendar> result = jsonb.fromJson("{\"value\":\"2015-04-03+01:00\"}", new TestTypeToken<ScalarValueWrapper<Calendar>>(){}.getType());
-        Assert.assertEquals(2015, result.getValue().get(Calendar.YEAR));
-        Assert.assertEquals(3, result.getValue().get(Calendar.MONTH));
-        Assert.assertEquals(3, result.getValue().get(Calendar.DAY_OF_MONTH));
-        Assert.assertEquals(0, result.getValue().get(Calendar.HOUR_OF_DAY));
-        Assert.assertEquals(0, result.getValue().get(Calendar.MINUTE));
-        Assert.assertEquals(0, result.getValue().get(Calendar.SECOND));
-        Assert.assertEquals("GMT+01:00", result.getValue().getTimeZone().toZoneId().toString());
+        ScalarValueWrapper<Calendar> result = bindingJsonb.fromJson("{\"value\":\"2015-04-03+01:00\"}", new TestTypeToken<ScalarValueWrapper<Calendar>>(){}.getType());
+        assertEquals(2015, result.getValue().get(Calendar.YEAR));
+        assertEquals(3, result.getValue().get(Calendar.MONTH));
+        assertEquals(3, result.getValue().get(Calendar.DAY_OF_MONTH));
+        assertEquals(0, result.getValue().get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, result.getValue().get(Calendar.MINUTE));
+        assertEquals(0, result.getValue().get(Calendar.SECOND));
+        assertEquals("GMT+01:00", result.getValue().getTimeZone().toZoneId().toString());
     }
 
     @Test
@@ -242,10 +232,10 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-04-03T10:10:10+02:00[" + zoneId + "]\"," +
                 "\"millisFormatted\":\"" + cal.getTimeInMillis() +
                 "\",\"customCalendar\":\"10:10:10 | 03-04-2015, +0200\"}";
-        assertEquals(expected, jsonb.toJson(calendarPojo));
+        assertEquals(expected, bindingJsonb.toJson(calendarPojo));
 
         // marshal to ISO_DATE_TIME
-        final CalendarPojo result = jsonb.fromJson(expected, CalendarPojo.class);
+        final CalendarPojo result = bindingJsonb.fromJson(expected, CalendarPojo.class);
         assertEquals(cal.getTime(), result.customCalendar.getTime());
         assertEquals(cal.getTime(), result.millisFormatted.getTime());
         assertEquals(cal.getTime(), result.defaultFormatted.getTime());
@@ -259,19 +249,19 @@ public class DatesTest {
         cal.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         // marshal to ISO_DATE
-        assertEquals("{\"value\":\"2015-04-03Z\"}", jsonb.toJson(new ScalarValueWrapper<>(cal)));
+        assertEquals("{\"value\":\"2015-04-03Z\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(cal)));
 
         // marshal to ISO_DATE_TIME
         final Calendar dateTimeGregorianCalendar = new Calendar.Builder().setDate(2015, 3, 3)
                 .setTimeZone(TimeZone.getTimeZone("Europe/Prague"))
                 .build();
-        assertEquals("{\"value\":\"2015-04-03T00:00:00+02:00[Europe/Prague]\"}", jsonb.toJson(new ScalarValueWrapper<>(dateTimeGregorianCalendar)));
+        assertEquals("{\"value\":\"2015-04-03T00:00:00+02:00[Europe/Prague]\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(dateTimeGregorianCalendar)));
     }
 
     @Test
     public void testMarshalTimeZone() {
-        assertEquals("{\"value\":\"Europe/Prague\"}", jsonb.toJson(new ScalarValueWrapper<>(TimeZone.getTimeZone("Europe/Prague"))));
-        assertEquals("{\"value\":\"Europe/Prague\"}", jsonb.toJson(new ScalarValueWrapper<>(SimpleTimeZone.getTimeZone("Europe/Prague"))));
+        assertEquals("{\"value\":\"Europe/Prague\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(TimeZone.getTimeZone("Europe/Prague"))));
+        assertEquals("{\"value\":\"Europe/Prague\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(SimpleTimeZone.getTimeZone("Europe/Prague"))));
     }
 
     @Test
@@ -282,9 +272,9 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-03-03T23:00:00Z\"," +
                 "\"millisFormatted\":\"1425423600000\"," +
                 "\"instant\":\"23:00:00 | 03-03-2015\"}";
-        assertEquals(expected, jsonb.toJson(instantPojo));
+        assertEquals(expected, bindingJsonb.toJson(instantPojo));
 
-        InstantPojo result = jsonb.fromJson(expected, InstantPojo.class);
+        InstantPojo result = bindingJsonb.fromJson(expected, InstantPojo.class);
         assertEquals(instant, result.defaultFormatted);
         assertEquals(instant, result.millisFormatted);
         assertEquals(instant, result.instant);
@@ -292,14 +282,14 @@ public class DatesTest {
 
     @Test
     public void testMarshalDuration() {
-        assertEquals("{\"value\":\"PT5H4M\"}", jsonb.toJson(new ScalarValueWrapper<>(Duration.ofHours(5).plusMinutes(4))));
+        assertEquals("{\"value\":\"PT5H4M\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(Duration.ofHours(5).plusMinutes(4))));
     }
 
     @Test
     public void testMarshalPeriod() {
         final Period period = Period.between(LocalDate.of(1960, Month.JANUARY, 1), LocalDate.of(1970, Month.JANUARY, 1));
         final ScalarValueWrapper<Period> value = new ScalarValueWrapper<>(period);
-        assertEquals("{\"value\":\"P10Y\"}", jsonb.toJson(value));
+        assertEquals("{\"value\":\"P10Y\"}", bindingJsonb.toJson(value));
     }
 
     @Test
@@ -313,9 +303,9 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-04-10\"," +
                 "\"millisFormatted\":\"" + millis + "\"," +
                 "\"customLocalDate\":\"10-04-2015\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final LocalDatePojo result = jsonb.fromJson(expected, LocalDatePojo.class);
+        final LocalDatePojo result = bindingJsonb.fromJson(expected, LocalDatePojo.class);
         assertEquals(localDate, result.customLocalDate);
         assertEquals(localDate, result.millisFormatted);
         assertEquals(localDate, result.defaultFormatted);
@@ -361,9 +351,9 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-02-16T13:21:00\"," +
                 "\"millisFormatted\":\"" + millis + "\"," +
                 "\"customLocalDate\":\"16-02-2015--00:21:13\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final LocalDateTimePojo result = jsonb.fromJson(expected, LocalDateTimePojo.class);
+        final LocalDateTimePojo result = bindingJsonb.fromJson(expected, LocalDateTimePojo.class);
         assertEquals(dateTime, result.defaultFormatted);
         assertEquals(dateTime, result.millisFormatted);
         assertEquals(dateTime, result.customLocalDate);
@@ -376,9 +366,9 @@ public class DatesTest {
         pojo.setValue(dateTime);
 
         final String expected = "{\"value\":\"2015-02-16T13:21:00\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final ScalarValueWrapper<LocalDateTime> result = jsonb.fromJson(expected, new TestTypeToken<ScalarValueWrapper<LocalDateTime>>(){}.getType());
+        final ScalarValueWrapper<LocalDateTime> result = bindingJsonb.fromJson(expected, new TestTypeToken<ScalarValueWrapper<LocalDateTime>>(){}.getType());
         assertEquals(dateTime, result.getValue());
     }
 
@@ -390,12 +380,12 @@ public class DatesTest {
         pojo.setValue(dateTime);
 
         final String expected = "{\"value\":\"2015-02-16T13:21:00\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
         final Jsonb jsonbCustom = JsonbBuilder.create(new JsonbConfig().withDateFormat(JsonbDateFormat.TIME_IN_MILLIS, Locale.FRENCH));
         assertEquals("{\"value\":\"" + millis + "\"}", jsonbCustom.toJson(pojo));
 
-        ScalarValueWrapper<LocalDateTime> result = this.jsonb.fromJson(expected, new TestTypeToken<ScalarValueWrapper<LocalDateTime>>(){}.getType());
+        ScalarValueWrapper<LocalDateTime> result = bindingJsonb.fromJson(expected, new TestTypeToken<ScalarValueWrapper<LocalDateTime>>(){}.getType());
         assertEquals(dateTime, result.getValue());
 
         result = jsonbCustom.fromJson("{\"value\":\"" + millis + "\"}", new TestTypeToken<ScalarValueWrapper<LocalDateTime>>(){}.getType());
@@ -411,26 +401,26 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-02-16T13:21:00+06:00[" + zone + "]\"," +
                 "\"millisFormatted\":\"" + dateTime.toInstant().toEpochMilli() + "\"," +
                 "\"customZonedDate\":\"+06" + zone + " | 16-02-2015--00:21:13\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final ZonedDateTimePojo result = jsonb.fromJson(expected, ZonedDateTimePojo.class);
+        final ZonedDateTimePojo result = bindingJsonb.fromJson(expected, ZonedDateTimePojo.class);
         assertEquals(dateTime, result.defaultFormatted);
         assertEquals(dateTime, result.customZonedDate);
 
         // time zone and seconds omitted
-        final ZonedDateTimePojo result1 = jsonb.fromJson("{\"defaultFormatted\":\"2015-02-16T13:21+06:00\"}", ZonedDateTimePojo.class);
+        final ZonedDateTimePojo result1 = bindingJsonb.fromJson("{\"defaultFormatted\":\"2015-02-16T13:21+06:00\"}", ZonedDateTimePojo.class);
         assertEquals(dateTime.getHour(), result1.defaultFormatted.getHour());
         assertEquals(dateTime.getOffset(), result1.defaultFormatted.getOffset());
     }
 
     @Test
     public void testMarshalZoneId() {
-        assertEquals("{\"value\":\"Europe/Prague\"}", jsonb.toJson(new ScalarValueWrapper<>(ZoneId.of("Europe/Prague"))));
+        assertEquals("{\"value\":\"Europe/Prague\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(ZoneId.of("Europe/Prague"))));
     }
 
     @Test
     public void testMarshalZoneOffset() {
-        assertEquals("{\"value\":\"+02:00\"}", jsonb.toJson(new ScalarValueWrapper<>(ZoneOffset.of("+02:00"))));
+        assertEquals("{\"value\":\"+02:00\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(ZoneOffset.of("+02:00"))));
     }
 
     @Test
@@ -441,9 +431,9 @@ public class DatesTest {
         final String expected = "{\"defaultFormatted\":\"2015-02-16T13:21:00+05:00\"," +
                 "\"millisFormatted\":\"1424074860000\"," +
                 "\"offsetDateTime\":\"+0500 16-02-2015--00:21:13\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final OffsetDateTimePojo result = jsonb.fromJson(expected, OffsetDateTimePojo.class);
+        final OffsetDateTimePojo result = bindingJsonb.fromJson(expected, OffsetDateTimePojo.class);
         assertEquals(dateTime, result.defaultFormatted);
         assertEquals(dateTime, result.offsetDateTime);
     }
@@ -480,9 +470,9 @@ public class DatesTest {
                 "\"calendar\":\"+06 ALMT ven. avril 03-04-2015 11:11:10\"," +
                 "\"defaultZoned\":\"2015-04-03T13:21:00+06:00[Asia/Almaty]\"," +
                 "\"zonedDateTime\":\"+06 ALMT ven. avril 03-04-2015 13:21:00\"}";
-        assertEquals(expected, jsonb.toJson(pojo));
+        assertEquals(expected, bindingJsonb.toJson(pojo));
 
-        final ClassLevelDateAnnotation result = jsonb.fromJson(expected, ClassLevelDateAnnotation.class);
+        final ClassLevelDateAnnotation result = bindingJsonb.fromJson(expected, ClassLevelDateAnnotation.class);
         assertEquals(pojo.date, result.date);
         assertEquals(pojo.localDateTime, result.localDateTime);
         assertEquals(pojo.calendar.getTime(), result.calendar.getTime());
@@ -514,18 +504,18 @@ public class DatesTest {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
         final Instant instant = Instant.from(formatter.withLocale(locale).parse("lun. 93 avr. 2017 16:51:12 CEST"));
-        Assert.assertEquals(instant, result.getValue().toInstant());
+        assertEquals(instant, result.getValue().toInstant());
     }
 
     @Test
     public void testSimpleTimeZone() {
-        String json = jsonb.toJson(new ScalarValueWrapper<>(new SimpleTimeZone(0, "America/Los_Angeles")));
-        Assert.assertEquals("{\"value\":\"America/Los_Angeles\"}", json);
+        String json = bindingJsonb.toJson(new ScalarValueWrapper<>(new SimpleTimeZone(0, "America/Los_Angeles")));
+        assertEquals("{\"value\":\"America/Los_Angeles\"}", json);
 
-        ScalarValueWrapper<TimeZone> result = jsonb.fromJson(json, new TestTypeToken<ScalarValueWrapper<TimeZone>>() {
+        ScalarValueWrapper<TimeZone> result = bindingJsonb.fromJson(json, new TestTypeToken<ScalarValueWrapper<TimeZone>>() {
         }.getType());
-        Assert.assertEquals("America/Los_Angeles", result.getValue().getID());
-        Assert.assertEquals(LocalDateTime.now().atZone(ZoneId.of("America/Los_Angeles")).getOffset().getTotalSeconds() * 1000,
+        assertEquals("America/Los_Angeles", result.getValue().getID());
+        assertEquals(LocalDateTime.now().atZone(ZoneId.of("America/Los_Angeles")).getOffset().getTotalSeconds() * 1000,
                 result.getValue().getOffset(System.currentTimeMillis()));
     }
 
@@ -545,14 +535,14 @@ public class DatesTest {
 
         String json = jsonb.toJson(pojo);
 
-        Assert.assertEquals("{\"dateMap\":{\"first\":\"2017\"},\"localDate\":\"2017\"}", json);
+        assertEquals("{\"dateMap\":{\"first\":\"2017\"},\"localDate\":\"2017\"}", json);
 
         config = new JsonbConfig()
                 .withDateFormat("dd.MM.yyyy", Locale.ENGLISH);
         jsonb = JsonbBuilder.create(config);
         DateInMapPojo result = jsonb.fromJson("{\"dateMap\":{\"first\":\"01.01.2017\"},\"localDate\":\"01.01.2017\"}", DateInMapPojo.class);
-        Assert.assertEquals(LocalDate.of(2017,1,1), result.localDate);
-        Assert.assertEquals(LocalDate.of(2017,1,1), result.dateMap.get("first"));
+        assertEquals(LocalDate.of(2017,1,1), result.localDate);
+        assertEquals(LocalDate.of(2017,1,1), result.dateMap.get("first"));
     }
 
     @Test
@@ -566,10 +556,10 @@ public class DatesTest {
         final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance()
                 .newXMLGregorianCalendar((GregorianCalendar) calendar);
 
-        String serialized = jsonb.toJson(xmlGregorianCalendar);
+        String serialized = bindingJsonb.toJson(xmlGregorianCalendar);
 
         assertEquals("\"2015-04-03T11:11:10+02:00[GMT+02:00]\"", serialized);
-        assertEquals(xmlGregorianCalendar, jsonb.fromJson(serialized, XMLGregorianCalendar.class));
+        assertEquals(xmlGregorianCalendar, bindingJsonb.fromJson(serialized, XMLGregorianCalendar.class));
     }
 
 

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -12,6 +12,9 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.dates;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.dates.model.CalendarPojo;
 import org.eclipse.yasson.defaultmapping.dates.model.ClassLevelDateAnnotation;
@@ -27,8 +30,6 @@ import org.eclipse.yasson.defaultmapping.dates.model.ZonedDateTimePojo;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
 import org.eclipse.yasson.internal.serializer.SqlDateTypeDeserializer;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -66,8 +67,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * This class contains tests for marshalling/unmarshalling dates.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
@@ -13,6 +13,9 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.generics;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.GenericBox;
 import org.eclipse.yasson.defaultmapping.generics.model.AnotherGenericTestClass;
@@ -33,11 +36,6 @@ import org.eclipse.yasson.defaultmapping.generics.model.WildCardClass;
 import org.eclipse.yasson.defaultmapping.generics.model.WildcardMultipleBoundsClass;
 import org.eclipse.yasson.serializers.model.Box;
 import org.eclipse.yasson.serializers.model.Crate;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -55,9 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * This class contains JSONB default mapping generics tests.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.defaultmapping.generics;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.adapters.model.GenericBox;
@@ -61,17 +62,6 @@ import java.util.TimeZone;
  */
 public class GenericsTest {
 
-    private Jsonb jsonb;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
-
     @Test
     public void testGenericClass() {
         GenericTestClass<String, Integer> genericClass = new GenericTestClass<>();
@@ -79,10 +69,10 @@ public class GenericsTest {
         genericClass.field2 = 3;
 
         String expected = "{\"field1\":\"value1\",\"field2\":3}";
-        assertEquals(expected, jsonb.toJson(genericClass));
+        assertEquals(expected, defaultJsonb.toJson(genericClass));
 
         Type type = new TestTypeToken<GenericTestClass<String, Integer>>(){}.getType();
-        GenericTestClass<String, Integer> result = jsonb.fromJson(expected, type);
+        GenericTestClass<String, Integer> result = defaultJsonb.fromJson(expected, type);
         assertEquals("value1", result.field1);
         assertEquals(Integer.valueOf(3), result.field2);
     }
@@ -103,10 +93,10 @@ public class GenericsTest {
         nestedGenericField.field2 = another;
 
         String expected = "{\"field1\":\"outerValue1\",\"field2\":{\"field1\":{\"field1\":\"innerMostValue3\",\"field2\":3},\"field2\":2}}";
-        assertEquals(expected, jsonb.toJson(nestedGenericField));
+        assertEquals(expected, defaultJsonb.toJson(nestedGenericField));
 
         Type type = new TestTypeToken<GenericTestClass<String, AnotherGenericTestClass<GenericTestClass<String, Integer>, Integer>>>(){}.getType();
-        GenericTestClass<String, AnotherGenericTestClass<GenericTestClass<String, Integer>, Integer>> result = jsonb.fromJson(expected, type);
+        GenericTestClass<String, AnotherGenericTestClass<GenericTestClass<String, Integer>, Integer>> result = defaultJsonb.fromJson(expected, type);
         assertEquals("outerValue1", result.field1);
         assertEquals(Integer.valueOf(2), result.field2.field2);
         assertEquals("innerMostValue3", result.field2.field1.field1);
@@ -124,10 +114,10 @@ public class GenericsTest {
         nestedGenericOnSelfClass.field2 = inner;
 
         String expected = "{\"field1\":\"outerValue1\",\"field2\":{\"field1\":\"innerValue1\",\"field2\":5}}";
-        assertEquals(expected, jsonb.toJson(nestedGenericOnSelfClass));
+        assertEquals(expected, defaultJsonb.toJson(nestedGenericOnSelfClass));
 
         Type type = new TestTypeToken<GenericTestClass<String, GenericTestClass<String, Integer>>>(){}.getType();
-        GenericTestClass<String, GenericTestClass<String, Integer>> result = jsonb.fromJson(expected, type);
+        GenericTestClass<String, GenericTestClass<String, Integer>> result = defaultJsonb.fromJson(expected, type);
         assertEquals("outerValue1", result.field1);
         assertEquals("innerValue1", result.field2.field1);
         assertEquals(Integer.valueOf(5), result.field2.field2);
@@ -142,8 +132,8 @@ public class GenericsTest {
         myCyclicGenericClass.field1 = cyclicSubClass;
 
         String expected = "{\"field1\":{\"subField\":\"subFieldValue\"}}";
-        assertEquals(expected, jsonb.toJson(myCyclicGenericClass));
-        MyCyclicGenericClass<CyclicSubClass> result = jsonb.fromJson(expected, new TestTypeToken<MyCyclicGenericClass<CyclicSubClass>>(){}.getType());
+        assertEquals(expected, defaultJsonb.toJson(myCyclicGenericClass));
+        MyCyclicGenericClass<CyclicSubClass> result = defaultJsonb.fromJson(expected, new TestTypeToken<MyCyclicGenericClass<CyclicSubClass>>(){}.getType());
         assertEquals(CyclicSubClass.class, result.field1.getClass());
         assertEquals("subFieldValue", result.field1.subField);
     }
@@ -155,8 +145,8 @@ public class GenericsTest {
 
         integerWildCard.number = 10;
         String expected = "{\"number\":10}";
-        assertEquals(expected, jsonb.toJson(integerWildCard));
-        WildCardClass<Integer> result = jsonb.fromJson(expected, new TestTypeToken<WildCardClass<Integer>>(){}.getType());
+        assertEquals(expected, defaultJsonb.toJson(integerWildCard));
+        WildCardClass<Integer> result = defaultJsonb.fromJson(expected, new TestTypeToken<WildCardClass<Integer>>(){}.getType());
         assertEquals(Integer.valueOf(10), result.number);
     }
 
@@ -172,9 +162,9 @@ public class GenericsTest {
         stringMap.put("k1", "v1");
         stringMap.put("k2", "v2");
         list.add(stringMap);
-        assertEquals(expected, jsonb.toJson(genericWithUnboundedWildcardClass));
+        assertEquals(expected, defaultJsonb.toJson(genericWithUnboundedWildcardClass));
 
-        GenericWithUnboundedWildcardClass result = jsonb.fromJson(expected, GenericWithUnboundedWildcardClass.class);
+        GenericWithUnboundedWildcardClass result = defaultJsonb.fromJson(expected, GenericWithUnboundedWildcardClass.class);
         assertTrue(result.wildcardList.get(0) instanceof Map);
         assertEquals("v1", ((Map) result.wildcardList.get(0)).get("k1"));
         assertEquals("v2", ((Map) result.wildcardList.get(0)).get("k2"));
@@ -196,10 +186,10 @@ public class GenericsTest {
         multipleBoundsClass.propagatedWildcardList = extendsBigDecimalList;
 
         String expected = "{\"genericTestClassPropagatedWildCard\":{\"field1\":\"genericTestClassField1\",\"field2\":10},\"propagatedWildcardList\":[11],\"wildcardField\":1}";
-        assertEquals(expected, jsonb.toJson(multipleBoundsClass, new WildcardMultipleBoundsClass<BigDecimal>(){}.getClass()));
+        assertEquals(expected, defaultJsonb.toJson(multipleBoundsClass, new WildcardMultipleBoundsClass<BigDecimal>(){}.getClass()));
 
 
-        WildcardMultipleBoundsClass<BigDecimal> result = jsonb.fromJson(expected, new TestTypeToken<WildcardMultipleBoundsClass<BigDecimal>>(){}.getType());
+        WildcardMultipleBoundsClass<BigDecimal> result = defaultJsonb.fromJson(expected, new TestTypeToken<WildcardMultipleBoundsClass<BigDecimal>>(){}.getType());
         assertEquals(BigDecimal.ONE, result.wildcardField);
         assertEquals("genericTestClassField1", result.genericTestClassPropagatedWildCard.field1);
         assertEquals(BigDecimal.TEN, result.genericTestClassPropagatedWildCard.field2);
@@ -212,7 +202,7 @@ public class GenericsTest {
         List<Optional<String>> expected = Arrays.asList(Optional.empty(), Optional.of("first"), Optional.of("second"));
         //String json = jsonb.toJson(expected, DefaultMappingGenericsTest.class.getField("listOfOptionalStringField").getGenericType());
 
-        String json = jsonb.toJson(expected);
+        String json = defaultJsonb.toJson(expected);
         assertEquals("[null,\"first\",\"second\"]", json);
     }
 
@@ -239,8 +229,8 @@ public class GenericsTest {
 
         String expected = "{\"genericList\":[{\"field1\":[1,2],\"field2\":\"GenericsInListF2\"}],\"genericTestClass\":{\"field1\":1,\"field2\":\"first\"}}";
 
-        assertEquals(expected, jsonb.toJson(propagatedGenericClass, new TestTypeToken<PropagatedGenericClass<Integer, String>>(){}.getType()));
-        PropagatedGenericClass<Integer, String> result = jsonb.fromJson(expected, new TestTypeToken<PropagatedGenericClass<Integer, String>>(){}.getType());
+        assertEquals(expected, defaultJsonb.toJson(propagatedGenericClass, new TestTypeToken<PropagatedGenericClass<Integer, String>>(){}.getType()));
+        PropagatedGenericClass<Integer, String> result = defaultJsonb.fromJson(expected, new TestTypeToken<PropagatedGenericClass<Integer, String>>(){}.getType());
         assertEquals(GenericTestClass.class, result.genericList.get(0).getClass());
         assertEquals(Integer.valueOf(1), result.genericList.get(0).field1.get(0));
         assertEquals(Integer.valueOf(2), result.genericList.get(0).field1.get(1));
@@ -266,9 +256,8 @@ public class GenericsTest {
         pojo.field1 = box;
         pojo.field2 = "GenericTestClass";
 
-        Assert.assertEquals(
-                "{\"field1\":{\"strField\":\"IntegerListBox\",\"x\":[1,2]},\"field2\":\"GenericTestClass\"}",
-                jsonb.toJson(pojo));
+        assertEquals("{\"field1\":{\"strField\":\"IntegerListBox\",\"x\":[1,2]},\"field2\":\"GenericTestClass\"}",
+                	defaultJsonb.toJson(pojo));
     }
 
 
@@ -289,7 +278,7 @@ public class GenericsTest {
             }
         };
 
-        assertEquals("{\"value\":\"initValue\"}", jsonb.toJson(myFunction));
+        assertEquals("{\"value\":\"initValue\"}", defaultJsonb.toJson(myFunction));
     }
 
     @Test
@@ -314,7 +303,7 @@ public class GenericsTest {
         boundedGenericClass.boundedSet = intSet;
 
         String expected = "{\"boundedSet\":[3],\"lowerBoundedList\":[{\"radius\":2.5}],\"upperBoundedList\":[{\"radius\":3.5,\"color\":\"0,0,255\"}]}";
-        assertEquals(expected, jsonb.toJson(boundedGenericClass));
+        assertEquals(expected, defaultJsonb.toJson(boundedGenericClass));
 
         Jsonb localJsonb = JsonbBuilder.create(new JsonbConfig());
         BoundedGenericClass<HashSet<Integer>, Circle> result = localJsonb.fromJson(expected,
@@ -333,12 +322,12 @@ public class GenericsTest {
     @Test
     public void testIncompatibleTypes() {
         //exception incompatible types
-        expectedException.expect(ClassCastException.class);
-
-        BoundedGenericClass<HashSet<Integer>, Circle> otherGeneric = jsonb.fromJson("{\"boundedSet\":[3],\"lowerBoundedList\":[{\"radius\":2.5}]}",
-                new TestTypeToken<BoundedGenericClass<HashSet<Double>, Circle>>(){}.getType());
-        HashSet<Integer> otherIntSet = otherGeneric.boundedSet;
-        Integer intValue = otherIntSet.iterator().next();
+    	assertThrows(ClassCastException.class, () -> {
+	        BoundedGenericClass<HashSet<Integer>, Circle> otherGeneric = defaultJsonb.fromJson("{\"boundedSet\":[3],\"lowerBoundedList\":[{\"radius\":2.5}]}",
+	                new TestTypeToken<BoundedGenericClass<HashSet<Double>, Circle>>(){}.getType());
+	        HashSet<Integer> otherIntSet = otherGeneric.boundedSet;
+	        Integer intValue = otherIntSet.iterator().next();
+    	});
     }
 
     @Test
@@ -348,8 +337,8 @@ public class GenericsTest {
         extended.field2 = 1;
 
         String expected = "{\"field1\":\"first\",\"field2\":1}";
-        assertEquals(expected, jsonb.toJson(extended));
-        MultiLevelExtendedGenericTestClass result = jsonb.fromJson(expected, MultiLevelExtendedGenericTestClass.class);
+        assertEquals(expected, defaultJsonb.toJson(extended));
+        MultiLevelExtendedGenericTestClass result = defaultJsonb.fromJson(expected, MultiLevelExtendedGenericTestClass.class);
         assertEquals("first", result.field1);
         assertEquals(Integer.valueOf(1), result.field2);
     }
@@ -373,8 +362,8 @@ public class GenericsTest {
         genericArrayClass.propagatedGenericArray = genericTestClass;
 
         String expected = "{\"anotherGenericArray\":[1,10],\"genericArray\":[1,10],\"propagatedGenericArray\":{\"field1\":[1,10],\"field2\":[1,10]}}";
-        assertEquals(expected, jsonb.toJson(genericArrayClass, new TestTypeToken<GenericArrayClass<Number,Integer>>(){}.getType()));
-        GenericArrayClass<Number, Integer> result = jsonb.fromJson(expected, new TestTypeToken<GenericArrayClass<Number, Integer>>(){}.getType());
+        assertEquals(expected, defaultJsonb.toJson(genericArrayClass, new TestTypeToken<GenericArrayClass<Number,Integer>>(){}.getType()));
+        GenericArrayClass<Number, Integer> result = defaultJsonb.fromJson(expected, new TestTypeToken<GenericArrayClass<Number, Integer>>(){}.getType());
         assertEquals(BigDecimal.ONE, result.genericArray[0]);
         assertEquals(BigDecimal.TEN, result.genericArray[1]);
         assertEquals(Integer.valueOf(1), result.anotherGenericArray[0]);
@@ -399,8 +388,7 @@ public class GenericsTest {
         box.crate.crateStr = "crate str";
         rawList.add(box);
 
-        final Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(rawList);
+        String result = defaultJsonb.toJson(rawList);
         assertEquals("[\"1981-03-24T00:00:00Z[UTC]\",{\"boxStr\":\"box string\",\"crate\":{\"crate_str\":\"crate str\"}}]", result);
     }
 
@@ -414,10 +402,10 @@ public class GenericsTest {
         final Type type = new TestTypeToken<MultipleBoundsContainer<LinkedList<String>>>() {
         }.getType();
 
-        String jsonString = jsonb.toJson(container, type);
-        Assert.assertEquals("{\"instance\":[[\"Test 1\",\"Test 2\"]]}", jsonString);
+        String jsonString = defaultJsonb.toJson(container, type);
+        assertEquals("{\"instance\":[[\"Test 1\",\"Test 2\"]]}", jsonString);
 
-        MultipleBoundsContainer<LinkedList<String>> result = jsonb.fromJson(jsonString, type);
+        MultipleBoundsContainer<LinkedList<String>> result = defaultJsonb.fromJson(jsonString, type);
 
         assertEquals(container.getInstance(), result.getInstance());
     }
@@ -426,9 +414,9 @@ public class GenericsTest {
     @SuppressWarnings("unchecked")
     public void testDeserializeIntoRaw() {
 
-        GenericTestClass result = jsonb.fromJson("{\"field1\":{\"val1\":\"abc\"},\"field2\":{\"val1\":\"def\"}}", GenericTestClass.class);
-        Assert.assertEquals(((HashMap<String, ?>) result.getField1()).get("val1"), "abc");
-        Assert.assertEquals(((HashMap<String, ?>) result.getField2()).get("val1"), "def");
+        GenericTestClass result = defaultJsonb.fromJson("{\"field1\":{\"val1\":\"abc\"},\"field2\":{\"val1\":\"def\"}}", GenericTestClass.class);
+        assertEquals(((HashMap<String, ?>) result.getField1()).get("val1"), "abc");
+        assertEquals(((HashMap<String, ?>) result.getField2()).get("val1"), "def");
     }
 
     @Test
@@ -438,7 +426,7 @@ public class GenericsTest {
 
         collectionWrapper.setWrappedCollection(new ArrayList<>());
         collectionWrapper.setWrappedMap(new HashMap<>());
-        String s = jsonb.toJson(collectionWrapper);
+        String s = defaultJsonb.toJson(collectionWrapper);
     }
 
     public interface FunctionalInterface<T> {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.yasson.defaultmapping.inheritance;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.GenericTestClass;
 import org.eclipse.yasson.defaultmapping.generics.model.PropagatedGenericClass;
@@ -23,9 +26,6 @@ import org.eclipse.yasson.defaultmapping.inheritance.model.generics.ExtendsExten
 import org.eclipse.yasson.defaultmapping.inheritance.model.generics.ExtendsPropagatedGenericClass;
 import org.eclipse.yasson.defaultmapping.inheritance.model.generics.ImplementsGenericInterfaces;
 import org.eclipse.yasson.defaultmapping.inheritance.model.generics.SecondLevelGeneric;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -33,8 +33,6 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests inheritance model marshalling / unmarshalling

--- a/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
@@ -79,7 +79,6 @@ public class InheritanceTest {
 
     @Test
     public void testPropagatedGenericInheritance() throws Exception {
-
         List<String> stringList = new ArrayList<>();
         stringList.add("first");
         stringList.add("second");
@@ -114,7 +113,6 @@ public class InheritanceTest {
 
     @Test
     public void testPropagatedGenericInheritance1() throws Exception {
-
         List<String> stringList = new ArrayList<>();
         stringList.add("first");
         stringList.add("second");
@@ -185,7 +183,6 @@ public class InheritanceTest {
 
     @Test
     public void testInterfaceGenericInheritance() throws Exception {
-
         ImplementsGenericInterfaces<String, Integer> implementsGenericInterfaces = new ImplementsGenericInterfaces<>();
 
         implementsGenericInterfaces.setGenericValue("GENERIC_VALUE");
@@ -214,7 +211,6 @@ public class InheritanceTest {
 
     @Test
     public void testPropOrderPartiallyOverriddenProperty() {
-
         PropertyOrderSecond pojo = new PropertyOrderSecond();
         pojo.setZero("ZERO");
         pojo.setZeroPartiallyOverriddenInFirst("ZERO_PARTIALLY_OVERRIDDEN_IN_FIRST");
@@ -226,5 +222,4 @@ public class InheritanceTest {
         assertEquals("{\"zero\":\"ZERO\",\"zeroPartiallyOverriddenInFirst\":\"ZERO_PARTIALLY_OVERRIDDEN_IN_FIRST\",\"first\":\"FIRST\",\"second\":\"SECOND\",\"zeroOverriddenInSecond\":\"ZERO_OVERRIDDEN_IN_SECOND\"}",
                 result);
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/inheritance/InheritanceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.defaultmapping.inheritance;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.GenericTestClass;
@@ -27,8 +28,6 @@ import org.eclipse.yasson.defaultmapping.inheritance.model.generics.ExtendsPropa
 import org.eclipse.yasson.defaultmapping.inheritance.model.generics.ImplementsGenericInterfaces;
 import org.eclipse.yasson.defaultmapping.inheritance.model.generics.SecondLevelGeneric;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -43,13 +42,6 @@ import java.util.List;
  */
 public class InheritanceTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void setUp() throws Exception {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testBasicInheritance() throws Exception {
         SecondLevel secondLevel = new SecondLevel();
@@ -58,9 +50,9 @@ public class InheritanceTest {
         secondLevel.setInZeroOverriddenInFirst("IN_ZERO_OVERRIDDEN_IN_FIRST");
 
         String json = "{\"inZeroOverriddenInFirst\":\"IN_ZERO_OVERRIDDEN_IN_FIRST\",\"inFirstLevel\":\"IN_FIRST_LEVEL\",\"inSecondLevel\":\"IN_SECOND_LEVEL\"}";
-        assertEquals(json, jsonb.toJson(secondLevel));
+        assertEquals(json, defaultJsonb.toJson(secondLevel));
 
-        SecondLevel result = jsonb.fromJson(json, SecondLevel.class);
+        SecondLevel result = defaultJsonb.fromJson(json, SecondLevel.class);
         assertEquals("IN_FIRST_LEVEL", result.getInFirstLevel());
         assertEquals("IN_SECOND_LEVEL", result.getInSecondLevel());
         assertEquals("IN_ZERO_OVERRIDDEN_IN_FIRST", result.getInZeroOverriddenInFirst());
@@ -76,9 +68,9 @@ public class InheritanceTest {
         secondLevelGeneric.setInZero("IN_ZERO");
 
         String json = "{\"inZero\":\"IN_ZERO\",\"inFirstLevel\":255,\"inZeroOverriddenInFirst\":\"IN_ZERO_OVERRIDDEN_IN_FIRST\",\"inSecondLevel\":10}";
-        assertEquals(json, jsonb.toJson(secondLevelGeneric));
+        assertEquals(json, defaultJsonb.toJson(secondLevelGeneric));
 
-        SecondLevelGeneric<Number, Short, String> result = jsonb.fromJson(json, new TestTypeToken<SecondLevelGeneric<Number, Short, String>>(){}.getType());
+        SecondLevelGeneric<Number, Short, String> result = defaultJsonb.fromJson(json, new TestTypeToken<SecondLevelGeneric<Number, Short, String>>(){}.getType());
         assertEquals(BigDecimal.TEN, result.getInSecondLevel());
         assertEquals(Short.valueOf("255"), result.getInFirstLevel());
         assertEquals("IN_ZERO_OVERRIDDEN_IN_FIRST", result.getInZeroOverriddenInFirst());
@@ -108,9 +100,9 @@ public class InheritanceTest {
         underTest.genericList = listWithGenerics;
 
         String json = "{\"genericList\":[{\"field1\":[\"first\",\"second\"],\"field2\":10}],\"genericTestClass\":{\"field1\":\"GENERIC_STRING\",\"field2\":1}}";
-        assertEquals(json, jsonb.toJson(underTest));
+        assertEquals(json, defaultJsonb.toJson(underTest));
 
-        ExtendsExtendsPropagatedGenericClass result = jsonb.fromJson(json, ExtendsExtendsPropagatedGenericClass.class);
+        ExtendsExtendsPropagatedGenericClass result = defaultJsonb.fromJson(json, ExtendsExtendsPropagatedGenericClass.class);
         assertEquals(GenericTestClass.class, result.genericList.get(0).getClass());
         assertEquals("first", result.genericList.get(0).field1.get(0));
         assertEquals("second", result.genericList.get(0).field1.get(1));
@@ -171,9 +163,9 @@ public class InheritanceTest {
         String json = "{\"inZero\":\"IN_ZERO\",\"inFirstLevel\":{\"genericList\":[{\"field1\":[\"third\",\"fourth\"],\"field2\":0}],\"genericTestClass\":{\"field1\":\"FIRST_LEVEL_GENERIC_STRING\",\"field2\":11}},\"inZeroOverriddenInFirst\":\"STRING_IN_ZERO_OVERRIDDEN_IN_FIRST\",\"inSecondLevel\":{\"genericList\":[{\"field1\":[\"first\",\"second\"],\"field2\":10}],\"genericTestClass\":{\"field1\":\"SECOND_LEVEL_GENERIC_STRING\",\"field2\":1}}}";
 
         final Type runtimeType = new TestTypeToken<SecondLevelGeneric<PropagatedGenericClass<String, BigDecimal>, ExtendsPropagatedGenericClass<String, BigDecimal>, String>>(){}.getType();
-        assertEquals(json, jsonb.toJson(secondLevelGeneric, runtimeType));
+        assertEquals(json, defaultJsonb.toJson(secondLevelGeneric, runtimeType));
         SecondLevelGeneric<PropagatedGenericClass<String, BigDecimal>, ExtendsPropagatedGenericClass<String, BigDecimal>, String> result =
-                jsonb.fromJson(json, runtimeType);
+        		defaultJsonb.fromJson(json, runtimeType);
 
         assertEquals("first", result.getInSecondLevel().genericList.get(0).field1.get(0));
         assertEquals("second", result.getInSecondLevel().genericList.get(0).field1.get(1));
@@ -200,9 +192,9 @@ public class InheritanceTest {
         implementsGenericInterfaces.setAnotherGenericValue(255);
 
         String json = "{\"anotherGenericValue\":255,\"genericValue\":\"GENERIC_VALUE\"}";
-        assertEquals(json, jsonb.toJson(implementsGenericInterfaces));
+        assertEquals(json, defaultJsonb.toJson(implementsGenericInterfaces));
 
-        ImplementsGenericInterfaces<String, Integer> result = jsonb.fromJson(json, new TestTypeToken<ImplementsGenericInterfaces<String, Integer>>(){}.getType());
+        ImplementsGenericInterfaces<String, Integer> result = defaultJsonb.fromJson(json, new TestTypeToken<ImplementsGenericInterfaces<String, Integer>>(){}.getType());
         assertEquals("GENERIC_VALUE", result.getGenericValue());
         assertEquals(Integer.valueOf(255), result.getAnotherGenericValue());
     }
@@ -212,12 +204,12 @@ public class InheritanceTest {
         PartialOverride partialOverride = new PartialOverride();
         partialOverride.setIntValue(5);
         partialOverride.setStrValue("abc");
-        String json = jsonb.toJson(partialOverride);
-        Assert.assertEquals("{\"intValue\":5,\"strValue\":\"abc\"}", json);
+        String json = defaultJsonb.toJson(partialOverride);
+        assertEquals("{\"intValue\":5,\"strValue\":\"abc\"}", json);
 
-        PartialOverride result = jsonb.fromJson("{\"intValue\":5,\"strValue\":\"abc\"}", PartialOverride.class);
-        Assert.assertEquals(5, result.getIntValue());
-        Assert.assertEquals("abc", result.getStrValue());
+        PartialOverride result = defaultJsonb.fromJson("{\"intValue\":5,\"strValue\":\"abc\"}", PartialOverride.class);
+        assertEquals(5, result.getIntValue());
+        assertEquals("abc", result.getStrValue());
     }
 
     @Test
@@ -230,8 +222,8 @@ public class InheritanceTest {
         pojo.setFirst("FIRST");
         pojo.setSecond("SECOND");
 
-        String result = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"zero\":\"ZERO\",\"zeroPartiallyOverriddenInFirst\":\"ZERO_PARTIALLY_OVERRIDDEN_IN_FIRST\",\"first\":\"FIRST\",\"second\":\"SECOND\",\"zeroOverriddenInSecond\":\"ZERO_OVERRIDDEN_IN_SECOND\"}",
+        String result = defaultJsonb.toJson(pojo);
+        assertEquals("{\"zero\":\"ZERO\",\"zeroPartiallyOverriddenInFirst\":\"ZERO_PARTIALLY_OVERRIDDEN_IN_FIRST\",\"first\":\"FIRST\",\"second\":\"SECOND\",\"zeroOverriddenInSecond\":\"ZERO_OVERRIDDEN_IN_SECOND\"}",
                 result);
     }
 

--- a/src/test/java/org/eclipse/yasson/defaultmapping/jsonp/JsonpTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/jsonp/JsonpTest.java
@@ -12,9 +12,10 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.jsonp;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.jsonp.model.JsonpPojo;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.*;
 import javax.json.bind.Jsonb;
@@ -22,8 +23,6 @@ import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 import javax.json.spi.JsonProvider;
 import java.math.BigDecimal;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Default mapping JSONP integration tests.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/jsonp/JsonpTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/jsonp/JsonpTest.java
@@ -14,6 +14,7 @@ package org.eclipse.yasson.defaultmapping.jsonp;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.defaultmapping.jsonp.model.JsonpPojo;
 
@@ -30,8 +31,6 @@ import java.math.BigDecimal;
  * @author Dmitry Kornilov
  */
 public class JsonpTest {
-
-    private Jsonb jsonb = JsonbBuilder.create();
 
     public static class JsonValueWrapper {
         public JsonValue jsonValue;
@@ -66,12 +65,12 @@ public class JsonpTest {
         final JsonObject wrapper = wrapperBuilder.build();
 
         String expected = "{\"f1\":\"abc\",\"cust\":{\"f1\":\"abc123\",\"f2\":10,\"f3\":12,\"city\":{\"name\":\"home\",\"city\":\"Prague\"}}}";
-        assertEquals(expected, jsonb.toJson(wrapper));
+        assertEquals(expected, defaultJsonb.toJson(wrapper));
 
-        JsonObject result = jsonb.fromJson(expected, JsonObject.class);
-        Assert.assertEquals("home", result.getJsonObject("cust").getJsonObject("city").getString("name"));
-        Assert.assertEquals("abc123", result.getJsonObject("cust").getString("f1"));
-        Assert.assertEquals("abc123", result.getJsonObject("cust").getString("f1"));
+        JsonObject result = defaultJsonb.fromJson(expected, JsonObject.class);
+        assertEquals("home", result.getJsonObject("cust").getJsonObject("city").getString("name"));
+        assertEquals("abc123", result.getJsonObject("cust").getString("f1"));
+        assertEquals("abc123", result.getJsonObject("cust").getString("f1"));
 
     }
 
@@ -84,22 +83,22 @@ public class JsonpTest {
                 .add(2)
                 .build();
 
-        assertEquals("{\"jsonValue\":[1,2]}", jsonb.toJson(new JsonValueWrapper(jsonArray)));
+        assertEquals("{\"jsonValue\":[1,2]}", defaultJsonb.toJson(new JsonValueWrapper(jsonArray)));
     }
 
     @Test
     public void testMarshallJsonValue() {
-        assertEquals("{\"jsonValue\":true}", jsonb.toJson(new JsonValueWrapper(JsonValue.TRUE)));
+        assertEquals("{\"jsonValue\":true}", defaultJsonb.toJson(new JsonValueWrapper(JsonValue.TRUE)));
     }
 
     @Test
     public void testMarshallJsonNumber() {
-                assertEquals("{\"jsonValue\":10}", jsonb.toJson(new JsonValueWrapper(new JsonpLong(10))));
+                assertEquals("{\"jsonValue\":10}", defaultJsonb.toJson(new JsonValueWrapper(new JsonpLong(10))));
     }
 
     @Test
     public void testMarshallJsonString() {
-                assertEquals("{\"jsonValue\":\"hello\"}", jsonb.toJson(new JsonValueWrapper(new JsonpString("hello"))));
+                assertEquals("{\"jsonValue\":\"hello\"}", defaultJsonb.toJson(new JsonValueWrapper(new JsonpString("hello"))));
     }
 
     @Test
@@ -158,9 +157,9 @@ public class JsonpTest {
         JsonObject object = objBuilder.build();
 
         String expected = "{\"boolTrue\":true,\"boolFalse\":false,\"null\":null,\"str\":\"String\",\"array\":[11,false,10]}";
-        assertEquals(expected, jsonb.toJson(object));
+        assertEquals(expected, defaultJsonb.toJson(object));
 
-        JsonObject result = jsonb.fromJson(expected, JsonObject.class);
+        JsonObject result = defaultJsonb.fromJson(expected, JsonObject.class);
 
         assertEquals(object, result);
     }
@@ -180,28 +179,28 @@ public class JsonpTest {
         JsonArray arr = arrBuilder.build();
 
         String expected = "[11,false,10,{\"boolTrue\":true,\"boolFalse\":false,\"null\":null,\"str\":\"String\"}]";
-        assertEquals(expected, jsonb.toJson(arr));
+        assertEquals(expected, defaultJsonb.toJson(arr));
 
-        JsonArray result = jsonb.fromJson(expected, JsonArray.class);
+        JsonArray result = defaultJsonb.fromJson(expected, JsonArray.class);
 
         assertEquals(arr, result);
     }
 
     @Test
     public void testJsonObjectAsValue() {
-        final JsonValueWrapper jsonValueWrapper = jsonb.fromJson("{ \"jsonValue\" : { \"stringInstance\" : \"Test String\" } }", JsonValueWrapper.class);
+        final JsonValueWrapper jsonValueWrapper = defaultJsonb.fromJson("{ \"jsonValue\" : { \"stringInstance\" : \"Test String\" } }", JsonValueWrapper.class);
         assertEquals("Test String", ((JsonObject) jsonValueWrapper.jsonValue).getString("stringInstance"));
     }
 
     @Test
     public void testJsonValueString() {
         JsonValueWrapper pojo = new JsonValueWrapper(Json.createValue("abc"));
-        String json = jsonb.toJson(pojo);
-        Assert.assertEquals("{\"jsonValue\":\"abc\"}", json);
+        String json = defaultJsonb.toJson(pojo);
+        assertEquals("{\"jsonValue\":\"abc\"}", json);
 
-        JsonValueWrapper result = jsonb.fromJson("{\"jsonValue\":\"def\"}", JsonValueWrapper.class);
-        Assert.assertTrue(result.jsonValue instanceof  JsonString);
-        Assert.assertEquals("def", ((JsonString)result.jsonValue).getString());
+        JsonValueWrapper result = defaultJsonb.fromJson("{\"jsonValue\":\"def\"}", JsonValueWrapper.class);
+        assertTrue(result.jsonValue instanceof  JsonString);
+        assertEquals("def", ((JsonString)result.jsonValue).getString());
     }
 
     @Test
@@ -212,14 +211,14 @@ public class JsonpTest {
                 .build();
         JsonValueWrapper pojo = new JsonValueWrapper(build);
         String expected = "{\"jsonValue\":{\"prop1\":\"val1\",\"prop2\":\"val2\",\"innerObj1\":{\"inner1\":\"innerVal1\"}}}";
-        String json = jsonb.toJson(pojo);
-        Assert.assertEquals(expected, json);
+        String json = defaultJsonb.toJson(pojo);
+        assertEquals(expected, json);
 
-        JsonValueWrapper result = jsonb.fromJson(expected, JsonValueWrapper.class);
-        Assert.assertTrue(result.jsonValue instanceof JsonObject);
+        JsonValueWrapper result = defaultJsonb.fromJson(expected, JsonValueWrapper.class);
+        assertTrue(result.jsonValue instanceof JsonObject);
         JsonObject jsonObject = (JsonObject) result.jsonValue;
-        Assert.assertEquals("val1", jsonObject.getString("prop1"));
-        Assert.assertEquals("innerVal1", jsonObject.getJsonObject("innerObj1").getString("inner1"));
+        assertEquals("val1", jsonObject.getString("prop1"));
+        assertEquals("innerVal1", jsonObject.getJsonObject("innerObj1").getString("inner1"));
     }
 
     @Test
@@ -227,16 +226,16 @@ public class JsonpTest {
         JsonArray jsonArray = Json.createArrayBuilder().add(1).add(2).add(3).add(Json.createObjectBuilder().add("a","b").build()).build();
         JsonValueWrapper pojo = new JsonValueWrapper(jsonArray);
         String expected = "{\"jsonValue\":[1,2,3,{\"a\":\"b\"}]}";
-        String json = jsonb.toJson(pojo);
-        Assert.assertEquals(expected, json);
+        String json = defaultJsonb.toJson(pojo);
+        assertEquals(expected, json);
 
-        JsonValueWrapper result = jsonb.fromJson(expected, JsonValueWrapper.class);
-        Assert.assertTrue(result.jsonValue instanceof JsonArray);
+        JsonValueWrapper result = defaultJsonb.fromJson(expected, JsonValueWrapper.class);
+        assertTrue(result.jsonValue instanceof JsonArray);
         JsonArray resultArray = (JsonArray) result.jsonValue;
-        Assert.assertEquals(1, resultArray.getInt(0));
-        Assert.assertEquals(2, resultArray.getInt(1));
-        Assert.assertEquals(3, resultArray.getInt(2));
-        Assert.assertEquals("b", resultArray.getJsonObject(3).getString("a"));
+        assertEquals(1, resultArray.getInt(0));
+        assertEquals(2, resultArray.getInt(1));
+        assertEquals(3, resultArray.getInt(2));
+        assertEquals("b", resultArray.getJsonObject(3).getString("a"));
 
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/lambda/LambdaExpressionTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/lambda/LambdaExpressionTest.java
@@ -1,8 +1,7 @@
 package org.eclipse.yasson.defaultmapping.lambda;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -27,7 +26,7 @@ public class LambdaExpressionTest {
         String name = "WALL-E";
         Addressable control = new Robot(name);
         Addressable lambda = () -> name;
-        Assert.assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
+        assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
     }
 
     @Test
@@ -35,6 +34,6 @@ public class LambdaExpressionTest {
         String name = "Cheshire";
         Pet control = new Cat(name);
         Pet lambda = () -> name;
-        Assert.assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
+        assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/lambda/LambdaExpressionTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/lambda/LambdaExpressionTest.java
@@ -2,9 +2,7 @@ package org.eclipse.yasson.defaultmapping.lambda;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
+import static org.eclipse.yasson.Jsonbs.*;
 
 /**
  * Test marshalling objects generated using lambda expressions.
@@ -14,19 +12,12 @@ import javax.json.bind.JsonbBuilder;
  */
 public class LambdaExpressionTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testMarshallFunctionalInterface() {
         String name = "WALL-E";
         Addressable control = new Robot(name);
         Addressable lambda = () -> name;
-        assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
+        assertEquals(defaultJsonb.toJson(control), defaultJsonb.toJson(lambda));
     }
 
     @Test
@@ -34,6 +25,6 @@ public class LambdaExpressionTest {
         String name = "Cheshire";
         Pet control = new Cat(name);
         Pet lambda = () -> name;
-        assertEquals(jsonb.toJson(control), jsonb.toJson(lambda));
+        assertEquals(defaultJsonb.toJson(control), defaultJsonb.toJson(lambda));
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/ClassModifiersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/ClassModifiersTest.java
@@ -15,14 +15,10 @@ package org.eclipse.yasson.defaultmapping.modifiers;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbException;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.Assertions;
 import org.eclipse.yasson.defaultmapping.modifiers.model.ChildOfPackagePrivateParent;
-import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
 
 /**
  * Test access modifiers on classes
@@ -31,21 +27,14 @@ import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
  */
 public class ClassModifiersTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testPackagePrivateParent() {
         ChildOfPackagePrivateParent child = new ChildOfPackagePrivateParent();
         child.id = 1;
         child.name = "SomeName";
-        String json = jsonb.toJson(child);
+        String json = defaultJsonb.toJson(child);
         assertEquals("{\"id\":1,\"name\":\"SomeName\"}", json);
-        ChildOfPackagePrivateParent result = jsonb.fromJson(json, ChildOfPackagePrivateParent.class);
+        ChildOfPackagePrivateParent result = defaultJsonb.fromJson(json, ChildOfPackagePrivateParent.class);
         assertEquals(child.id, result.id);
         assertEquals(child.name, result.name);
     }
@@ -64,7 +53,7 @@ public class ClassModifiersTest {
         NestedPackageChild child = new NestedPackageChild();
         child.id = 1;
         child.name = "SomeName";
-        Assertions.shouldFail(() -> jsonb.toJson(child),
+        Assertions.shouldFail(() -> defaultJsonb.toJson(child),
                 msg -> msg.contains("Unable to serialize property 'id'") &&
                 msg.contains("java.lang.IllegalAccessException")); 
     }
@@ -82,7 +71,7 @@ public class ClassModifiersTest {
         NestedPrivateChild child = new NestedPrivateChild();
         child.id = 1;
         child.name = "SomeName";
-        Assertions.shouldFail(() -> jsonb.toJson(child),
+        Assertions.shouldFail(() -> defaultJsonb.toJson(child),
                 msg -> msg.contains("java.lang.IllegalAccessException"));
     }
 
@@ -100,7 +89,7 @@ public class ClassModifiersTest {
         NestedStaticPackageChild child = new NestedStaticPackageChild();
         child.id = 1;
         child.name = "SomeName";
-        Assertions.shouldFail(() -> jsonb.toJson(child),
+        Assertions.shouldFail(() -> defaultJsonb.toJson(child),
                 msg -> msg.contains("java.lang.IllegalAccessException"));
     }
 
@@ -117,7 +106,7 @@ public class ClassModifiersTest {
         NestedStaticPrivateChild child = new NestedStaticPrivateChild();
         child.id = 1;
         child.name = "SomeName";
-        Assertions.shouldFail(() -> jsonb.toJson(child),
+        Assertions.shouldFail(() -> defaultJsonb.toJson(child),
                 msg -> msg.contains("java.lang.IllegalAccessException"));
     }
 

--- a/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/ClassModifiersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/ClassModifiersTest.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.yasson.defaultmapping.modifiers;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
@@ -20,13 +23,6 @@ import javax.json.bind.JsonbException;
 import org.eclipse.yasson.Assertions;
 import org.eclipse.yasson.defaultmapping.modifiers.model.ChildOfPackagePrivateParent;
 import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test access modifiers on classes

--- a/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
@@ -15,16 +15,14 @@ package org.eclipse.yasson.defaultmapping.modifiers;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.defaultmapping.modifiers.model.Person;
 import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.MethodModifiersClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.PrivateConstructorClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.ProtectedConstructorClass;
-import org.eclipse.yasson.internal.JsonBindingBuilder;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 
 /**
@@ -34,18 +32,11 @@ import javax.json.bind.JsonbException;
  */
 public class DefaultMappingModifiersTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testFieldModifiers() {
         FieldModifiersClass fieldModifiersClass = new FieldModifiersClass();
-        assertEquals("{\"finalString\":\"FINAL_STRING\"}", jsonb.toJson(fieldModifiersClass));
-        FieldModifiersClass result = jsonb.fromJson("{\"finalString\":\"FINAL_STRING\",\"staticString\":\"STATIC_STRING\",\"transientString\":\"TRANSIENT_STRING\"}", FieldModifiersClass.class);
+        assertEquals("{\"finalString\":\"FINAL_STRING\"}", defaultJsonb.toJson(fieldModifiersClass));
+        FieldModifiersClass result = defaultJsonb.fromJson("{\"finalString\":\"FINAL_STRING\",\"staticString\":\"STATIC_STRING\",\"transientString\":\"TRANSIENT_STRING\"}", FieldModifiersClass.class);
         //no setter throwing illegal has been called.
     }
 
@@ -55,12 +46,12 @@ public class DefaultMappingModifiersTest {
         methodModifiers.publicFieldWithoutMethods = "WITHOUT_METHODS";
 
         String validJson = "{\"getterWithoutFieldValue\":\"GETTER_WITHOUT_FIELD\",\"publicFieldWithoutMethods\":\"WITHOUT_METHODS\"}";
-        assertEquals(validJson, jsonb.toJson(methodModifiers));
+        assertEquals(validJson, defaultJsonb.toJson(methodModifiers));
 
-        MethodModifiersClass result = jsonb.fromJson("{\"publicFieldWithPrivateMethods\":\"value\"}", MethodModifiersClass.class);
+        MethodModifiersClass result = defaultJsonb.fromJson("{\"publicFieldWithPrivateMethods\":\"value\"}", MethodModifiersClass.class);
         assertNull(result.publicFieldWithPrivateMethods);
 
-        result = jsonb.fromJson(validJson, MethodModifiersClass.class);
+        result = defaultJsonb.fromJson(validJson, MethodModifiersClass.class);
         assertEquals("WITHOUT_METHODS", result.publicFieldWithoutMethods);
 
     }
@@ -68,14 +59,14 @@ public class DefaultMappingModifiersTest {
     @Test
     public void testConstructorModifiers() {
         try{
-            ProtectedConstructorClass instance = jsonb.fromJson("{\"randomField\":\"test\"}", ProtectedConstructorClass.class);
+            ProtectedConstructorClass instance = defaultJsonb.fromJson("{\"randomField\":\"test\"}", ProtectedConstructorClass.class);
             assertEquals(instance.randomField, "test");
         } catch (JsonbException e){
             fail("No exception should be thrown for protected constructor");
             throw e;
         }
         try {
-            jsonb.fromJson("{\"randomField\":\"test\"}", PrivateConstructorClass.class);
+        	defaultJsonb.fromJson("{\"randomField\":\"test\"}", PrivateConstructorClass.class);
             fail("Exception should have been thrown");
         }catch (JsonbException e){
             assertTrue(e.getMessage().endsWith("Can't create instance"));
@@ -84,14 +75,13 @@ public class DefaultMappingModifiersTest {
 
     @Test
     public void testMultipleInstancesOfSameType() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
         Person person = new Person();
         Person personTwo = new Person();
         person.name = "Person 1";
         personTwo.name = "Person 2";
         person.child = personTwo;
 
-        assertEquals("{\"child\":{\"name\":\"Person 2\"},\"name\":\"Person 1\"}",jsonb.toJson(person));
+        assertEquals("{\"child\":{\"name\":\"Person 2\"},\"name\":\"Person 1\"}", bindingJsonb.toJson(person));
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
@@ -13,20 +13,19 @@
 
 package org.eclipse.yasson.defaultmapping.modifiers;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.modifiers.model.Person;
 import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.MethodModifiersClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.PrivateConstructorClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.ProtectedConstructorClass;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
-
-import static org.junit.Assert.*;
 
 /**
  * Test access modifiers for default mapping.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/modifiers/DefaultMappingModifiersTest.java
@@ -53,7 +53,6 @@ public class DefaultMappingModifiersTest {
 
         result = defaultJsonb.fromJson(validJson, MethodModifiersClass.class);
         assertEquals("WITHOUT_METHODS", result.publicFieldWithoutMethods);
-
     }
 
     @Test
@@ -83,5 +82,4 @@ public class DefaultMappingModifiersTest {
 
         assertEquals("{\"child\":{\"name\":\"Person 2\"},\"name\":\"Person 1\"}", bindingJsonb.toJson(person));
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/properties/PropertiesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/properties/PropertiesTest.java
@@ -12,15 +12,14 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.properties;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.properties.MessageKeys;
 import org.eclipse.yasson.internal.properties.Messages;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Locale;
-
-import static org.junit.Assert.assertEquals;
-
 
 /**
  * This class contains properties tests

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/CustomerTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/CustomerTest.java
@@ -56,7 +56,7 @@ public abstract class CustomerTest {
         assertEquals(Integer.valueOf(2), customer.getStringIntegerMap().get("second"));*/
     }
 
-    protected Customer createCustomer(String customerName) {
+    protected static Customer createCustomer(String customerName) {
         Street street = new Street("Zoubkova", 111);
         Address address = new Address(street, "Prague");
         Customer customer = new Customer(33, customerName);

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/CustomerTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/CustomerTest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.specific.model.Address;
 import org.eclipse.yasson.defaultmapping.specific.model.Customer;
 import org.eclipse.yasson.defaultmapping.specific.model.Street;
@@ -21,8 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/JsonStreamsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/JsonStreamsTest.java
@@ -13,8 +13,10 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -25,8 +27,6 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests calling JSONB with {@link java.util.stream.Stream} and {@link Readable}

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/JsonStreamsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/JsonStreamsTest.java
@@ -15,11 +15,10 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
@@ -34,19 +33,17 @@ import java.util.Map;
  * @author Roman Grigoriadi
  */
 public class JsonStreamsTest {
-
     private static final String CHARSET = "UTF8";
-    private Jsonb jsonb = JsonbBuilder.create();
 
     @Test
     public void testUnmarshall() throws Exception {
 
         String json = "{\"key1\":\"value1\",\"key2\":\"value2\"}";
 
-        Map<String, String> result = jsonb.fromJson(new InputStreamReader(new ByteArrayInputStream(json.getBytes(CHARSET)), Charset.forName(CHARSET)), new TestTypeToken<HashMap<String, String>>(){}.getType());
+        Map<String, String> result = defaultJsonb.fromJson(new InputStreamReader(new ByteArrayInputStream(json.getBytes(CHARSET)), Charset.forName(CHARSET)), new TestTypeToken<HashMap<String, String>>(){}.getType());
         assertMapValues(result);
 
-        result = jsonb.fromJson(new ByteArrayInputStream(json.getBytes(CHARSET)), new TestTypeToken<HashMap<String, String>>() {}.getType());
+        result = defaultJsonb.fromJson(new ByteArrayInputStream(json.getBytes(CHARSET)), new TestTypeToken<HashMap<String, String>>() {}.getType());
         assertMapValues(result);
     }
 
@@ -60,18 +57,18 @@ public class JsonStreamsTest {
         strMap.put("key2", "value2");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream(len);
-        jsonb.toJson(strMap, baos);
+        defaultJsonb.toJson(strMap, baos);
         assertEquals(expected, baos.toString(CHARSET));
 
         baos = new ByteArrayOutputStream(len);
         OutputStreamWriter writer = new OutputStreamWriter(baos, Charset.forName(CHARSET));
-        jsonb.toJson(strMap, writer);
+        defaultJsonb.toJson(strMap, writer);
         writer.close();
 
         assertEquals(expected, baos.toString(CHARSET));
     }
 
-    private void assertMapValues(Map<String, String> result) {
+    private static void assertMapValues(Map<String, String> result) {
         assertEquals(2, result.size());
         assertEquals("value1", result.get("key1"));
         assertEquals("value2", result.get("key2"));

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
@@ -16,13 +16,10 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.specific.model.Street;
-import org.eclipse.yasson.internal.JsonBindingBuilder;
-
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -32,18 +29,11 @@ import java.util.Map;
  */
 public class NullTest {
 
-    private Jsonb jsonb;
-
-    @Before
-    public void before() {
-        jsonb = JsonbBuilder.create();
-    }
-
     @Test
     public void testSetsNullIntoFields() {
         String json = "{\"name\":null,\"number\":null}";
 
-        Street result = jsonb.fromJson(json, Street.class);
+        Street result = defaultJsonb.fromJson(json, Street.class);
         //these have default initialization value
         assertNull(result.getName());
         assertNull(result.getNumber());
@@ -51,22 +41,22 @@ public class NullTest {
 
     @Test
     public void testDeserializeNull() {
-        assertNull(jsonb.fromJson("null", Object.class));
+        assertNull(defaultJsonb.fromJson("null", Object.class));
     }
 
     @Test
     public void testDeserializeNullPojo() {
-        assertNull(jsonb.fromJson("null", Street.class));
+        assertNull(defaultJsonb.fromJson("null", Street.class));
     }
 
     @Test
     public void testDeserializeNullList() {
-        assertNull(jsonb.fromJson("null", new TestTypeToken<List<Integer>>() {}.getType()));
+        assertNull(defaultJsonb.fromJson("null", new TestTypeToken<List<Integer>>() {}.getType()));
     }
 
     @Test
     public void testDeserializeNullMap() {
-        assertNull(jsonb.fromJson("null", new TestTypeToken<Map<String, Street>>() {}.getType()));
+        assertNull(defaultJsonb.fromJson("null", new TestTypeToken<Map<String, Street>>() {}.getType()));
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/NullTest.java
@@ -14,19 +14,18 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.specific.model.Street;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/ObjectGraphTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/ObjectGraphTest.java
@@ -15,11 +15,10 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.defaultmapping.specific.model.Customer;
-import org.eclipse.yasson.internal.JsonBindingBuilder;
 
-import javax.json.bind.Jsonb;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +26,6 @@ import java.util.Map;
  * @author Roman Grigoriadi
  */
 public class ObjectGraphTest extends CustomerTest {
-
     private static final String EXPECTED = "{\"addresses\":[{\"street\":{\"name\":\"Zoubkova\",\"number\":111},\"town\":\"Prague\"}],\"age\":33,\"friends\":{\"firstFriend\":{\"addresses\":[{\"street\":{\"name\":\"Zoubkova\",\"number\":111},\"town\":\"Prague\"}],\"age\":33,\"integers\":[0,1],\"listOfListsOfIntegers\":[[0,1,2],[0,1,2],[0,1,2]],\"name\":\"Jasons first friend\",\"stringIntegerMap\":{\"first\":1,\"second\":2},\"strings\":[\"green\",\"yellow\"]},\"secondFriend\":{\"addresses\":[{\"street\":{\"name\":\"Zoubkova\",\"number\":111},\"town\":\"Prague\"}],\"age\":33,\"integers\":[0,1],\"listOfListsOfIntegers\":[[0,1,2],[0,1,2],[0,1,2]],\"name\":\"Jasons second friend\",\"stringIntegerMap\":{\"first\":1,\"second\":2},\"strings\":[\"green\",\"yellow\"]}},\"integers\":[0,1],\"listOfListsOfIntegers\":[[0,1,2],[0,1,2],[0,1,2]],\"name\":\"Root Jason Customer\",\"stringIntegerMap\":{\"first\":1,\"second\":2},\"strings\":[\"green\",\"yellow\"]}";
 
     @Test
@@ -39,18 +37,15 @@ public class ObjectGraphTest extends CustomerTest {
         friends.put("secondFriend", createCustomer("Jasons second friend"));
         customer.setFriends(friends);
 
-        Jsonb jsonb = new JsonBindingBuilder().build();
-        assertEquals(EXPECTED, jsonb.toJson(customer));
+        assertEquals(EXPECTED, bindingJsonb.toJson(customer));
     }
 
     @Test
     public void testObjectFromJson() {
-        Jsonb jsonb = new JsonBindingBuilder().build();
-        Customer customer = jsonb.fromJson(EXPECTED, Customer.class);
+        Customer customer = bindingJsonb.fromJson(EXPECTED, Customer.class);
         assertCustomerValues(customer, "Root Jason Customer");
         assertEquals(2, customer.getFriends().size());
         assertCustomerValues(customer.getFriends().get("firstFriend"), "Jasons first friend");
         assertCustomerValues(customer.getFriends().get("secondFriend"), "Jasons second friend");
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/ObjectGraphTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/ObjectGraphTest.java
@@ -13,15 +13,15 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.specific.model.Customer;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
@@ -14,22 +14,19 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 import org.eclipse.yasson.defaultmapping.specific.model.OptionalWrapper;
 import org.eclipse.yasson.defaultmapping.specific.model.NotMatchingGettersAndSetters;
 import org.eclipse.yasson.defaultmapping.specific.model.Street;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Default mapping Optional* tests.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/OptionalTest.java
@@ -16,6 +16,7 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
@@ -38,23 +39,21 @@ public class OptionalTest {
 
     @Test
     public void testOptionalString() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{\"value\":\"abc\"}", jsonb.toJson(new ScalarValueWrapper<>(Optional.of("abc"))));
+        assertEquals("{\"value\":\"abc\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(Optional.of("abc"))));
 
-        ScalarValueWrapper<Optional> result = jsonb.fromJson("{\"value\":\"abc\"}", new TestTypeToken<ScalarValueWrapper<Optional>>() {}.getType());
+        ScalarValueWrapper<Optional> result = bindingJsonb.fromJson("{\"value\":\"abc\"}", new TestTypeToken<ScalarValueWrapper<Optional>>() {}.getType());
         assertEquals(Optional.of("abc"), result.getValue());
     }
 
     @Test
     public void testOptionalObject() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
         final OptionalWrapper optionalWrapper = new OptionalWrapper();
         Street street = new Street("Xaveriova", 110);
         optionalWrapper.setStreetOptional(Optional.of(street));
 
-        assertEquals("{\"streetOptional\":{\"name\":\"Xaveriova\",\"number\":110}}", jsonb.toJson(optionalWrapper));
+        assertEquals("{\"streetOptional\":{\"name\":\"Xaveriova\",\"number\":110}}", bindingJsonb.toJson(optionalWrapper));
 
-        OptionalWrapper result = jsonb.fromJson("{\"streetOptional\":{\"name\":\"Xaveriova\",\"number\":110}}", OptionalWrapper.class);
+        OptionalWrapper result = bindingJsonb.fromJson("{\"streetOptional\":{\"name\":\"Xaveriova\",\"number\":110}}", OptionalWrapper.class);
         assertTrue(result.getStreetOptional().isPresent());
         assertEquals("Xaveriova", result.getStreetOptional().get().getName());
         assertEquals(Integer.valueOf(110), result.getStreetOptional().get().getNumber());
@@ -62,34 +61,30 @@ public class OptionalTest {
 
     @Test
     public void testMarshallOptional() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{}", jsonb.toJson(new ScalarValueWrapper<>(OptionalInt.empty())));
-        assertEquals("{}", jsonb.toJson(new ScalarValueWrapper<>(OptionalLong.empty())));
-        assertEquals("{}", jsonb.toJson(new ScalarValueWrapper<>(OptionalDouble.empty())));
-        assertEquals("{\"value\":10}", jsonb.toJson(new ScalarValueWrapper<>(OptionalInt.of(10))));
-        assertEquals("{\"value\":100}", jsonb.toJson(new ScalarValueWrapper<>(OptionalLong.of(100L))));
-        assertEquals("{\"value\":10.0}", jsonb.toJson(new ScalarValueWrapper<>(OptionalDouble.of(10.0D))));
+        assertEquals("{}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalInt.empty())));
+        assertEquals("{}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalLong.empty())));
+        assertEquals("{}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalDouble.empty())));
+        assertEquals("{\"value\":10}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalInt.of(10))));
+        assertEquals("{\"value\":100}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalLong.of(100L))));
+        assertEquals("{\"value\":10.0}", bindingJsonb.toJson(new ScalarValueWrapper<>(OptionalDouble.of(10.0D))));
 
-        final ScalarValueWrapper<OptionalInt> result = jsonb.fromJson("{\"value\":10}", new TestTypeToken<ScalarValueWrapper<OptionalInt>>() {}.getType());
+        final ScalarValueWrapper<OptionalInt> result = bindingJsonb.fromJson("{\"value\":10}", new TestTypeToken<ScalarValueWrapper<OptionalInt>>() {}.getType());
         assertEquals(OptionalInt.of(10), result.getValue());
     }
 
     @Test
     public void testMarshallOptionalObject() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{}", jsonb.toJson(new ScalarValueWrapper<>(Optional.empty())));
-        assertEquals("{\"id\":1,\"name\":\"Cust1\"}", jsonb.toJson(Optional.of(new Customer(1, "Cust1"))));
+        assertEquals("{}", bindingJsonb.toJson(new ScalarValueWrapper<>(Optional.empty())));
+        assertEquals("{\"id\":1,\"name\":\"Cust1\"}", bindingJsonb.toJson(Optional.of(new Customer(1, "Cust1"))));
 
     }
 
     @Test
     public void testMarshallOptionalIntArray() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
         final OptionalInt[] array = {OptionalInt.of(1), OptionalInt.of(2), OptionalInt.empty()};
-        assertEquals("[1,2,null]", jsonb.toJson(array));
+        assertEquals("[1,2,null]", bindingJsonb.toJson(array));
 
-        OptionalInt[] result = jsonb.fromJson("[1,2,null]", new TestTypeToken<OptionalInt[]>() {}.getType());
+        OptionalInt[] result = bindingJsonb.fromJson("[1,2,null]", new TestTypeToken<OptionalInt[]>() {}.getType());
 
         assertTrue(result[0].isPresent());
         assertEquals(1, result[0].getAsInt());
@@ -102,44 +97,36 @@ public class OptionalTest {
 
     @Test
     public void testMarshallOptionalArray() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
         final Optional[] array = {Optional.of(new Customer(1, "Cust1")), Optional.of(new Customer(2, "Cust2")), Optional.empty()};
-        assertEquals("[{\"id\":1,\"name\":\"Cust1\"},{\"id\":2,\"name\":\"Cust2\"},null]", jsonb.toJson(array));
+        assertEquals("[{\"id\":1,\"name\":\"Cust1\"},{\"id\":2,\"name\":\"Cust2\"},null]", bindingJsonb.toJson(array));
     }
 
     @Test
     public void testUnmarshallNullAsOptionalEmpty() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
-        final ScalarValueWrapper<OptionalInt> result = jsonb.fromJson("{\"value\":null}", new ScalarValueWrapper<OptionalInt>() {
+        final ScalarValueWrapper<OptionalInt> result = bindingJsonb.fromJson("{\"value\":null}", new ScalarValueWrapper<OptionalInt>() {
         }.getClass().getGenericSuperclass());
-        Assert.assertEquals(OptionalInt.empty(), result.getValue());
+        assertEquals(OptionalInt.empty(), result.getValue());
     }
 
     @Test
     public void testUnmarshallOptionalArrayNulls() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
-        final OptionalLong[] result = jsonb.fromJson("[null, null]", OptionalLong[].class);
+        final OptionalLong[] result = bindingJsonb.fromJson("[null, null]", OptionalLong[].class);
 
         assertEquals(2, result.length);
 
         for (OptionalLong item : result) {
-            Assert.assertEquals(OptionalLong.empty(), item);
+            assertEquals(OptionalLong.empty(), item);
         }
     }
 
     @Test
     public void testUnmarshallOptionalList() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
-        final List<Optional<Integer>> result = jsonb.fromJson("[null, null]", new TestTypeToken<List<Optional<Integer>>>() {}.getType());
+        final List<Optional<Integer>> result = bindingJsonb.fromJson("[null, null]", new TestTypeToken<List<Optional<Integer>>>() {}.getType());
 
         assertEquals(2, result.size());
 
         for (Optional<Integer> item : result) {
-            Assert.assertEquals(Optional.empty(), item);
+            assertEquals(Optional.empty(), item);
         }
     }
 
@@ -148,69 +135,59 @@ public class OptionalTest {
         Map<String, OptionalInt> ints = new HashMap<>();
         ints.put("first", OptionalInt.empty());
         ints.put("second", OptionalInt.empty());
-        final Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(ints);
-        Assert.assertEquals("{\"first\":null,\"second\":null}", result);
+        String result = defaultJsonb.toJson(ints);
+        assertEquals("{\"first\":null,\"second\":null}", result);
     }
 
     @Test
     public void testCorrectOptionalGetter() {
         NotMatchingGettersAndSetters personWithCorrectGetter = new NotMatchingGettersAndSetters();
-        final Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(personWithCorrectGetter);
+        String result = defaultJsonb.toJson(personWithCorrectGetter);
         assertEquals("{\"firstName\":1,\"lastName\":\"Correct\"}", result);
 
-        NotMatchingGettersAndSetters deserialized = jsonb.fromJson(result, NotMatchingGettersAndSetters.class);
+        NotMatchingGettersAndSetters deserialized = defaultJsonb.fromJson(result, NotMatchingGettersAndSetters.class);
         personWithCorrectGetter.setFirstName(1);
         assertEquals(personWithCorrectGetter, deserialized);
     }
 
     @Test
     public void testMarshalEmptyRoot() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("null", jsonb.toJson(Optional.empty()));
+        assertEquals("null", bindingJsonb.toJson(Optional.empty()));
     }
 
     @Test
     public void testUnmarshalEmptyRoot() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals(Optional.empty(), jsonb.fromJson("null", new TestTypeToken<Optional<Customer>>() {}.getType()));
+        assertEquals(Optional.empty(), bindingJsonb.fromJson("null", new TestTypeToken<Optional<Customer>>() {}.getType()));
     }
 
     @Test
     public void testMarshalEmptyInt() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("null", jsonb.toJson(OptionalInt.empty()));
+        assertEquals("null", bindingJsonb.toJson(OptionalInt.empty()));
     }
 
     @Test
     public void testUnmarshalEmptyInt() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals(OptionalInt.empty(), jsonb.fromJson("null", OptionalInt.class));
+        assertEquals(OptionalInt.empty(), bindingJsonb.fromJson("null", OptionalInt.class));
     }
 
     @Test
     public void testMarshalEmptyLong() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("null", jsonb.toJson(OptionalLong.empty()));
+        assertEquals("null", bindingJsonb.toJson(OptionalLong.empty()));
     }
 
     @Test
     public void testUnmarshalEmptyLong() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals(OptionalLong.empty(), jsonb.fromJson("null", OptionalLong.class));
+        assertEquals(OptionalLong.empty(), bindingJsonb.fromJson("null", OptionalLong.class));
     }
 
     @Test
     public void testMarshalEmptyDouble() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("null", jsonb.toJson(OptionalDouble.empty()));
+        assertEquals("null", bindingJsonb.toJson(OptionalDouble.empty()));
     }
 
     @Test
     public void testUnmarshalEmptyDouble() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals(OptionalDouble.empty(), jsonb.fromJson("null", OptionalDouble.class));
+        assertEquals(OptionalDouble.empty(), bindingJsonb.fromJson("null", OptionalDouble.class));
     }
 
     public static class Customer {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/SpecificTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/SpecificTest.java
@@ -14,11 +14,10 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
-import org.eclipse.yasson.internal.JsonBindingBuilder;
 
-import javax.json.bind.Jsonb;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
@@ -34,26 +33,22 @@ import java.net.URL;
 public class SpecificTest {
     @Test
     public void testMarshallBigDecimal() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{\"value\":100}", jsonb.toJson(new ScalarValueWrapper<>(BigDecimal.valueOf(100L))));
-        assertEquals("{\"value\":100.1}", jsonb.toJson(new ScalarValueWrapper<>(BigDecimal.valueOf(100.1D))));
+        assertEquals("{\"value\":100}", bindingJsonb.toJson(new ScalarValueWrapper<>(BigDecimal.valueOf(100L))));
+        assertEquals("{\"value\":100.1}", bindingJsonb.toJson(new ScalarValueWrapper<>(BigDecimal.valueOf(100.1D))));
     }
 
     @Test
     public void testMarshallBigInteger() {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{\"value\":100}", jsonb.toJson(new ScalarValueWrapper<>(BigInteger.valueOf(100))));
+        assertEquals("{\"value\":100}", bindingJsonb.toJson(new ScalarValueWrapper<>(BigInteger.valueOf(100))));
     }
 
     @Test
     public void testMarshallUri() throws URISyntaxException {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{\"value\":\"http://www.oracle.com\"}", jsonb.toJson(new ScalarValueWrapper<>(new URI("http://www.oracle.com"))));
+        assertEquals("{\"value\":\"http://www.oracle.com\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(new URI("http://www.oracle.com"))));
     }
 
     @Test
     public void testMarshallUrl() throws MalformedURLException {
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-        assertEquals("{\"value\":\"http://www.oracle.com\"}", jsonb.toJson(new ScalarValueWrapper<>(new URL("http://www.oracle.com"))));
+        assertEquals("{\"value\":\"http://www.oracle.com\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(new URL("http://www.oracle.com"))));
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/SpecificTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/SpecificTest.java
@@ -12,9 +12,11 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import java.math.BigDecimal;
@@ -23,8 +25,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Specific standard Java SE types tests: {@link BigDecimal}, {@link BigInteger}, {@link URL}, {@link URI}.

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.defaultmapping.specific;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.GenericTestClass;
@@ -45,8 +46,6 @@ import static org.eclipse.yasson.YassonProperties.FAIL_ON_UNKNOWN_PROPERTIES;
  */
 public class UnmarshallingUnsupportedTypesTest {
 
-    private final Jsonb jsonb = JsonbBuilder.create();
-
     @Test
     public void testUnmarshallToUnsupportedInterface() {
         ClassWithUnsupportedFields unsupported = new ClassWithUnsupportedFields();
@@ -64,9 +63,9 @@ public class UnmarshallingUnsupportedTypesTest {
             }
         };
         String expected = "{\"customInterface\":{\"value\":\"value1\"}}";
-        assertEquals(expected, jsonb.toJson(unsupported));
+        assertEquals(expected, defaultJsonb.toJson(unsupported));
         try {
-            jsonb.fromJson(expected, ClassWithUnsupportedFields.class);
+        	defaultJsonb.fromJson(expected, ClassWithUnsupportedFields.class);
             fail("Should report an error");
         } catch (JsonbException e) {
             assertTrue(e.getMessage().contains("Cannot infer a type"));
@@ -88,9 +87,9 @@ public class UnmarshallingUnsupportedTypesTest {
         supportedTypes.getNestedPojo().setIntegerValue(10);
 
         String json = "{\"instant\":\"2015-12-28T14:57:00Z\",\"nestedPojo\":{\"integerValue\":10},\"optionalLong\":11,\"zonedDateTime\":\"2015-12-28T15:57:00+01:00[Europe/Prague]\"}";
-        assertEquals(json, jsonb.toJson(supportedTypes));
+        assertEquals(json, defaultJsonb.toJson(supportedTypes));
 
-        SupportedTypes result = jsonb.fromJson(json, SupportedTypes.class);
+        SupportedTypes result = defaultJsonb.fromJson(json, SupportedTypes.class);
         assertEquals(result.getInstant(), supportedTypes.getInstant());
         assertEquals(result.getZonedDateTime(), supportedTypes.getZonedDateTime());
         assertEquals(result.getOptionalLong(), supportedTypes.getOptionalLong());
@@ -114,27 +113,27 @@ public class UnmarshallingUnsupportedTypesTest {
 
     @Test()
     public void testMissingFieldDefault() {
-        Jsonb defaultConfig = JsonbBuilder.create();
         String json  = "{\"nestedPojo\":{\"integerValue\":10,\"missingField\":5},\"optionalLong\":11}";
-        SupportedTypes result = defaultConfig.fromJson(json, SupportedTypes.class);
+        SupportedTypes result = defaultJsonb.fromJson(json, SupportedTypes.class);
         assertEquals(Integer.valueOf(10), result.getNestedPojo().getIntegerValue());
         assertEquals(11, result.getOptionalLong().getAsLong());
     }
 
     @Test()
     public void testMissingFieldDefaultNull() {
-        Jsonb defaultConfig = JsonbBuilder.create();
         String json  = "{\"nestedPojo\":{\"integerValue\":10,\"missingField\":null},\"optionalLong\":11}";
-        SupportedTypes result = defaultConfig.fromJson(json, SupportedTypes.class);
+        SupportedTypes result = defaultJsonb.fromJson(json, SupportedTypes.class);
         assertEquals(Integer.valueOf(10), result.getNestedPojo().getIntegerValue());
         assertEquals(11, result.getOptionalLong().getAsLong());
     }
 
-    @Test(expected = JsonbException.class)
+    @Test
     public void testMissingFieldIgnored() {
-        Jsonb defaultConfig = JsonbBuilder.create(new JsonbConfig().setProperty(FAIL_ON_UNKNOWN_PROPERTIES, true));
-        String json  = "{\"nestedPojo\":{\"integerValue\":10,\"missingField\":5},\"optionalLong\":11}";
-        SupportedTypes result = defaultConfig.fromJson(json, SupportedTypes.class);
+    	assertThrows(JsonbException.class, () -> {
+	        Jsonb defaultConfig = JsonbBuilder.create(new JsonbConfig().setProperty(FAIL_ON_UNKNOWN_PROPERTIES, true));
+	        String json  = "{\"nestedPojo\":{\"integerValue\":10,\"missingField\":5},\"optionalLong\":11}";
+	        SupportedTypes result = defaultConfig.fromJson(json, SupportedTypes.class);
+    	});
     }
 
     @Test
@@ -205,7 +204,7 @@ public class UnmarshallingUnsupportedTypesTest {
 
     private void assertFail(String json, Type type, String failureProperty, Class<?> failurePropertyClass) {
         try {
-            jsonb.fromJson(json, type);
+        	defaultJsonb.fromJson(json, type);
             fail();
         } catch (JsonbException e) {
             if(!e.getMessage().contains(failureProperty) || !e.getMessage().contains(failurePropertyClass.getName())) {

--- a/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/specific/UnmarshallingUnsupportedTypesTest.java
@@ -13,13 +13,15 @@
 
 package org.eclipse.yasson.defaultmapping.specific;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.GenericTestClass;
 import org.eclipse.yasson.defaultmapping.specific.model.ClassWithUnsupportedFields;
 import org.eclipse.yasson.defaultmapping.specific.model.CustomUnsupportedInterface;
 import org.eclipse.yasson.defaultmapping.specific.model.SupportedTypes;
 import org.eclipse.yasson.defaultmapping.specific.model.SupportedTypes.NestedPojo;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -37,7 +39,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 import static org.eclipse.yasson.YassonProperties.FAIL_ON_UNKNOWN_PROPERTIES;
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
@@ -12,11 +12,13 @@
  ******************************************************************************/
 package org.eclipse.yasson.defaultmapping.typeConvertors;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
 import org.eclipse.yasson.defaultmapping.typeConvertors.model.ByteArrayWrapper;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -24,9 +26,6 @@ import javax.json.bind.JsonbConfig;
 import javax.json.bind.config.BinaryDataStrategy;
 import java.util.Base64;
 import java.util.UUID;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 /**
  * This class contains Converter tests

--- a/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/typeConvertors/DefaultSerializersTest.java
@@ -14,6 +14,7 @@ package org.eclipse.yasson.defaultmapping.typeConvertors;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.defaultmapping.generics.model.ScalarValueWrapper;
@@ -21,7 +22,6 @@ import org.eclipse.yasson.defaultmapping.typeConvertors.model.ByteArrayWrapper;
 import org.eclipse.yasson.internal.JsonBindingBuilder;
 
 import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbConfig;
 import javax.json.bind.config.BinaryDataStrategy;
 import java.util.Base64;
@@ -34,22 +34,18 @@ import java.util.UUID;
  */
 public class DefaultSerializersTest {
 
-    private final Jsonb jsonb = JsonbBuilder.create();
-
     @Test
     public void testCharacter() {
         final String json = "{\"value\":\"\uFFFF\"}";
-        assertEquals(json, jsonb.toJson(new ScalarValueWrapper<>('\uFFFF')));
-        ScalarValueWrapper<Character> result = jsonb.fromJson(json, new TestTypeToken<ScalarValueWrapper<Character>>(){}.getType());
+        assertEquals(json, defaultJsonb.toJson(new ScalarValueWrapper<>('\uFFFF')));
+        ScalarValueWrapper<Character> result = defaultJsonb.fromJson(json, new TestTypeToken<ScalarValueWrapper<Character>>(){}.getType());
         assertEquals((Character)'\uFFFF', result.getValue());
     }
 
     @Test
     public void testByteArray() {
         byte[] array = {1, 2, 3};
-        final Jsonb jsonb = (new JsonBindingBuilder()).build();
-
-        assertEquals("[1,2,3]", jsonb.toJson(array));
+        assertEquals("[1,2,3]", bindingJsonb.toJson(array));
     }
 
     @Test
@@ -115,10 +111,9 @@ public class DefaultSerializersTest {
 
     @Test
     public void testUUID() {
-        Jsonb jsonb = JsonbBuilder.create();
         UUID uuid = UUID.randomUUID();
-        String json = jsonb.toJson(uuid);
-        UUID result = jsonb.fromJson(json, UUID.class);
+        String json = defaultJsonb.toJson(uuid);
+        UUID result = defaultJsonb.fromJson(json, UUID.class);
         assertEquals(uuid, result);
     }
 }

--- a/src/test/java/org/eclipse/yasson/documented/DocumentationExampleTest.java
+++ b/src/test/java/org/eclipse/yasson/documented/DocumentationExampleTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.yasson.documented;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -26,8 +26,6 @@ import javax.json.bind.serializer.JsonbSerializer;
 import javax.json.bind.serializer.SerializationContext;
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonParser;
-
-import org.junit.Test;
 
 /**
  * Contains tests from http://json-b.net/docs/user-guide.html

--- a/src/test/java/org/eclipse/yasson/documented/DocumentationExampleTest.java
+++ b/src/test/java/org/eclipse/yasson/documented/DocumentationExampleTest.java
@@ -2,6 +2,7 @@ package org.eclipse.yasson.documented;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -47,12 +48,11 @@ public class DocumentationExampleTest {
         dog.bitable = false;
 
         // Create Jsonb and serialize
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(dog);
+        String result = defaultJsonb.toJson(dog);
         assertEquals("{\"age\":4,\"bitable\":false,\"name\":\"Falco\"}", result);
 
         // Deserialize back
-        dog = jsonb.fromJson("{\"name\":\"Falco\",\"age\":4,\"bites\":false}", Dog.class);
+        dog = defaultJsonb.fromJson("{\"name\":\"Falco\",\"age\":4,\"bites\":false}", Dog.class);
         assertEquals("Falco", dog.name);
         assertEquals(4, dog.age);
         assertEquals(false, dog.bitable);
@@ -74,8 +74,7 @@ public class DocumentationExampleTest {
         dogs.add(cassidy);
 
         // Create Jsonb and serialize
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(dogs);
+        String result = defaultJsonb.toJson(dogs);
         assertEquals(
                 "[{\"age\":4,\"bitable\":false,\"name\":\"Falco\"},{\"age\":5,\"bitable\":false,\"name\":\"Cassidy\"}]",
                 result);
@@ -83,7 +82,7 @@ public class DocumentationExampleTest {
         // We can also deserialize back into a raw collection, but since there is no way
         // to infer a type here,
         // the result will be a list of java.util.Map instances with string keys.
-        dogs = jsonb.fromJson(result, ArrayList.class);
+        dogs = defaultJsonb.fromJson(result, ArrayList.class);
         assertEquals(2, dogs.size());
         assertEquals("Falco", ((Map) dogs.get(0)).get("name"));
         assertEquals("Cassidy", ((Map) dogs.get(1)).get("name"));
@@ -108,14 +107,13 @@ public class DocumentationExampleTest {
         dogs.add(cassidy);
 
         // Create Jsonb and serialize
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(dogs);
+        String result = defaultJsonb.toJson(dogs);
         assertEquals(
                 "[{\"age\":4,\"bitable\":false,\"name\":\"Falco\"},{\"age\":5,\"bitable\":false,\"name\":\"Cassidy\"}]",
                 result);
 
         // Deserialize back
-        dogs = jsonb.fromJson(result, new ArrayList<Dog>() {
+        dogs = defaultJsonb.fromJson(result, new ArrayList<Dog>() {
         }.getClass().getGenericSuperclass());
         assertEquals(2, dogs.size());
         assertEquals("Falco", dogs.get(0).name);
@@ -128,14 +126,8 @@ public class DocumentationExampleTest {
         pojo.name = "Falco";
         pojo.age = 4;
 
-        // Create custom configuration with formatted output
-        JsonbConfig config = new JsonbConfig().withFormatting(true);
-
-        // Create Jsonb with custom configuration
-        Jsonb jsonb = JsonbBuilder.create(config);
-
         // Use it!
-        String result = jsonb.toJson(pojo);
+        String result = formattingJsonb.toJson(pojo);
         assertEquals("\n" + 
                 "{\n" + 
                 "    \"age\": 4,\n" + 
@@ -155,8 +147,8 @@ public class DocumentationExampleTest {
         Person1 p = new Person1();
         p.name = "Jason Bourne";
         p.profession = "Super Agent";
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withFormatting(true));
-        String result = jsonb.toJson(p);
+        
+        String result = formattingJsonb.toJson(p);
         assertEquals("\n" +
                 "{\n" + 
                 "    \"person-name\": \"Jason Bourne\",\n" + 
@@ -191,8 +183,8 @@ public class DocumentationExampleTest {
         Person2 p = new Person2();
         p.name = "Jason Bourne";
         p.profession = "Super Agent";
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withFormatting(true));
-        String result = jsonb.toJson(p);
+        
+        String result = formattingJsonb.toJson(p);
         assertEquals("\n" +
                 "{\n" + 
                 "    \"person-name\": \"Jason Bourne\",\n" + 
@@ -218,12 +210,11 @@ public class DocumentationExampleTest {
     public void testChangingPropertyNames3() {
         Person3 p = new Person3();
         p.name = "Jason Bourne";
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(p);
+        String result = defaultJsonb.toJson(p);
         assertEquals("{\"name-to-write\":\"Jason Bourne\"}", result);
         
         String json = "{\"name-to-read\":\"Jason Bourne\"}";
-        Person3 after = jsonb.fromJson(json, Person3.class);
+        Person3 after = defaultJsonb.fromJson(json, Person3.class);
         assertEquals("Jason Bourne", after.name);
     }
     
@@ -253,12 +244,11 @@ public class DocumentationExampleTest {
         Person4 p = new Person4();
         p.name = "Jason Bourne";
         p.profession = "Super Agent";
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(p);
+        String result = defaultJsonb.toJson(p);
         assertEquals("{\"profession\":\"Super Agent\"}", result);
         
         String json = "{\"profession\":\"Super Agent\"}";
-        Person4 after = jsonb.fromJson(json, Person4.class);
+        Person4 after = defaultJsonb.fromJson(json, Person4.class);
         assertEquals("Super Agent", after.profession);
         assertNull(after.name);
     }
@@ -286,8 +276,7 @@ public class DocumentationExampleTest {
     @Test
     public void testNullHandling1() {
         Person5 p = new Person5();
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(p);
+        String result = defaultJsonb.toJson(p);
         assertEquals("{\"name\":null,\"profession\":null}", result);
     }
     
@@ -315,8 +304,7 @@ public class DocumentationExampleTest {
     @Test
     public void testNullHandling2() {
         Person6 p = new Person6();
-        Jsonb jsonb = JsonbBuilder.create();
-        String result = jsonb.toJson(p);
+        String result = defaultJsonb.toJson(p);
         assertEquals("{\"name\":null}", result);
     }
     
@@ -328,8 +316,7 @@ public class DocumentationExampleTest {
     @Test
     public void testNullHandling3() {
         Person p = new Person();
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(true));
-        String result = jsonb.toJson(p);
+        String result = nullableJsonb.toJson(p);
         assertEquals("{\"name\":null,\"profession\":null}", result);
     }
     
@@ -345,8 +332,7 @@ public class DocumentationExampleTest {
     
     @Test
     public void testCustomInstantiation() {
-        Jsonb jsonb = JsonbBuilder.create();
-        Person8 p = jsonb.fromJson("{\"name\":\"Jason Bourne\"}", Person8.class);
+        Person8 p = defaultJsonb.fromJson("{\"name\":\"Jason Bourne\"}", Person8.class);
         assertEquals("Jason Bourne", p.name);
     }
     
@@ -366,11 +352,10 @@ public class DocumentationExampleTest {
         p.name = "Jason Bourne";
         p.birthDate = LocalDate.of(1999, 8, 7);
         p.salary = new BigDecimal("123.45678");
-        Jsonb jsonb = JsonbBuilder.create();
-        String json = jsonb.toJson(p);
+        String json = defaultJsonb.toJson(p);
         assertEquals("{\"birthDate\":\"07.08.1999\",\"name\":\"Jason Bourne\",\"salary\":\"123.46\"}", json);
         
-        Person9 after = jsonb.fromJson("{\"birthDate\":\"07.08.1999\",\"name\":\"Jason Bourne\",\"salary\":\"123.46\"}", Person9.class);
+        Person9 after = defaultJsonb.fromJson("{\"birthDate\":\"07.08.1999\",\"name\":\"Jason Bourne\",\"salary\":\"123.46\"}", Person9.class);
         assertEquals(p.name, after.name);
         assertEquals(p.birthDate, after.birthDate);
         assertEquals(new BigDecimal("123.46"), after.salary);
@@ -474,9 +459,6 @@ public class DocumentationExampleTest {
     
     @Test
     public void testAdapters1() {
-        // Create Jsonb with default configuration
-        Jsonb jsonb = JsonbBuilder.create();
-
         // Create customer
         Customer customer = new Customer();
 
@@ -486,7 +468,7 @@ public class DocumentationExampleTest {
         customer.setPosition("Super Agent");
 
         // Serialize
-        String json = jsonb.toJson(customer);
+        String json = defaultJsonb.toJson(customer);
         assertEquals("{\"id\":1,\"name\":\"Jason Bourne\",\"organization\":\"Super Agents\",\"position\":\"Super Agent\"}", json);
     }
     

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationFinderTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationFinderTest.java
@@ -1,12 +1,11 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.eclipse.yasson.internal.AnnotationFinderTestFixtures.TESTVALUE;
 import static org.eclipse.yasson.internal.AnnotationFinderTestFixtures.getConstructorAnnotationsOf;
 import static org.eclipse.yasson.internal.AnnotationFinderTestFixtures.getMethodAnnotationsOf;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.AnnotationAnnotatedWithDeprecated;
 import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.AnnotationWithoutValueProperty;
@@ -19,8 +18,6 @@ import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.ObjectWithInheri
 import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.ObjectWithInheritedDeprecatedMethod;
 import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.ObjectWithMissingValuePropertyAnnotation;
 import org.eclipse.yasson.internal.AnnotationFinderTestFixtures.ObjectWithNoAnnotations;
-
-import org.junit.Test;
 
 public class AnnotationFinderTest {
 

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationFinderTestFixtures.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationFinderTestFixtures.java
@@ -1,5 +1,7 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
@@ -10,9 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.Ignore;
-
-@Ignore
+@Disabled
 class AnnotationFinderTestFixtures {
 
     public static final String TESTVALUE = "testvalue";
@@ -47,14 +47,14 @@ class AnnotationFinderTestFixtures {
     }
 
     public static class ObjectWithIgnoredMethod {
-        @Ignore
+        @Disabled
         public void annotatedMethod() {
             // empty
         }
     }
 
     public static class ObjectWithDeprecatedAndIgnoredMethod {
-        @Ignore
+    	@Disabled
         @Deprecated
         public void annotatedMethod() {
             // empty
@@ -69,7 +69,7 @@ class AnnotationFinderTestFixtures {
     }
 
     public static class ObjectWithIgnoredAndInheritedDeprecatedMethod {
-        @Ignore
+    	@Disabled
         @AnnotationAnnotatedWithDeprecated
         public void annotatedMethod() {
             // empty

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTest.java
@@ -1,8 +1,10 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertCreatedInstanceContainsAllParameters;
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertParameters;
-import static org.junit.Assert.assertNull;
 
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithJsonbCreatorAndConstructorPropertiesAnnotation;
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithJsonbCreatorAnnotatedConstructor;
@@ -18,12 +20,6 @@ import javax.json.bind.JsonbException;
 
 import javax.json.spi.JsonProvider;
 
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 /**
  * Tests the {@link AnnotationIntrospector}.
  * 
@@ -31,16 +27,12 @@ import org.junit.rules.ExpectedException;
  * @see AnnotationIntrospectorTestAsserts
  */
 public class AnnotationIntrospectorTest {
-
-    private JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
+    private final JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
 
     /**
      * class under test.
      */
     private AnnotationIntrospector instrospector = new AnnotationIntrospector(jsonbContext);
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testObjectShouldBeCreateableFromJsonbAnnotatedConstructor() {
@@ -65,14 +57,14 @@ public class AnnotationIntrospectorTest {
 
     @Test
     public void testJsonbAnnotatedProtectedConstructorLeadsToAnException() {
-        exception.expect(JsonbException.class);
-        exception.expectCause(IsInstanceOf.instanceOf(IllegalAccessException.class));
-        JsonbCreator creator = instrospector.getCreator(ObjectWithJsonbCreatorAnnotatedProtectedConstructor.class);
-        assertCreatedInstanceContainsAllParameters(ObjectWithJsonbCreatorAnnotatedProtectedConstructor.example(), creator);
+        assertThrows(JsonbException.class, () -> {
+	        JsonbCreator creator = instrospector.getCreator(ObjectWithJsonbCreatorAnnotatedProtectedConstructor.class);
+	        assertCreatedInstanceContainsAllParameters(ObjectWithJsonbCreatorAnnotatedProtectedConstructor.example(), creator);
+        });
     }
 
     // TODO Under discussion: https://github.com/eclipse-ee4j/yasson/issues/326
-    @Ignore
+    @Disabled
     @Test
     public void testNoArgConstructorShouldBePreferredOverUnusableJsonbAnnotatedProtectedConstructor() {
         JsonbCreator creator = instrospector.getCreator(ObjectWithNoArgAndJsonbCreatorAnnotatedProtectedConstructor.class);
@@ -82,9 +74,9 @@ public class AnnotationIntrospectorTest {
 
     @Test
     public void testMoreThanOneAnnotatedCreatorMethodShouldLeadToAnException() {
-        exception.expect(JsonbException.class);
-        exception.expectMessage("More than one @" + JsonbCreator.class.getSimpleName());
-        instrospector.getCreator(ObjectWithTwoJsonbCreatorAnnotatedSpots.class);
+        assertThrows(JsonbException.class, 
+        			() -> instrospector.getCreator(ObjectWithTwoJsonbCreatorAnnotatedSpots.class),
+        			() -> "More than one @" + JsonbCreator.class.getSimpleName());
     }
 
     @Test

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTestAsserts.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTestAsserts.java
@@ -1,8 +1,7 @@
 package org.eclipse.yasson.internal;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ProvidesParameterRepresentation;
 import org.eclipse.yasson.internal.model.CreatorModel;
@@ -12,9 +11,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.junit.Ignore;
-
-@Ignore
+@Disabled
 class AnnotationIntrospectorTestAsserts {
 
     /**
@@ -25,7 +22,7 @@ class AnnotationIntrospectorTestAsserts {
      * @param creator  {@link JsonbCreator}
      */
     public static <T extends ProvidesParameterRepresentation> void assertCreatedInstanceContainsAllParameters(T expected, JsonbCreator creator) {
-        assertNotNull(JsonbCreator.class.getSimpleName() + " expected", creator);
+        assertNotNull(creator, JsonbCreator.class.getSimpleName() + " expected");
         @SuppressWarnings("unchecked")
         T created = (T) creator.call(expected.asParameters(), expected.getClass());
         assertArrayEquals(expected.asParameters(), created.asParameters());
@@ -38,7 +35,7 @@ class AnnotationIntrospectorTestAsserts {
      * @param creator            CreatorModel
      */
     public static void assertParameters(Map<String, Type> expectedParameters, JsonbCreator creator) {
-        assertNotNull(JsonbCreator.class.getSimpleName() + " expected", creator);
+        assertNotNull(creator, JsonbCreator.class.getSimpleName() + " expected");
         for (Entry<String, Type> parameter : expectedParameters.entrySet()) {
             CreatorModel creatorModel = creator.findByName(parameter.getKey());
             assertEquals(parameter.getKey(), creatorModel.getName());

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTestFixtures.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorTestFixtures.java
@@ -1,5 +1,7 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+
 import javax.json.bind.annotation.JsonbCreator;
 import javax.json.bind.annotation.JsonbProperty;
 
@@ -11,9 +13,7 @@ import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Ignore;
-
-@Ignore
+@Disabled
 class AnnotationIntrospectorTestFixtures {
 
     public static interface ProvidesParameterRepresentation {

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorWithoutOptionalModulesTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorWithoutOptionalModulesTest.java
@@ -25,12 +25,10 @@ import javax.json.spi.JsonProvider;
  */
 public class AnnotationIntrospectorWithoutOptionalModulesTest {
 
-    private JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
-
     /**
      * class under test.
      */
-    private AnnotationIntrospector instrospector = new AnnotationIntrospector(jsonbContext);
+    private static final AnnotationIntrospector instrospector = new AnnotationIntrospector(new JsonbContext(new JsonbConfig(), JsonProvider.provider()));
 
     @Test
     public void testNoConstructorPropertiesAnnotationWithoutOptionalModules() {

--- a/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorWithoutOptionalModulesTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/AnnotationIntrospectorWithoutOptionalModulesTest.java
@@ -1,8 +1,10 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertCreatedInstanceContainsAllParameters;
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertParameters;
-import static org.junit.Assert.assertNull;
 
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithJsonbCreatorAnnotatedConstructor;
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithJsonbCreatorAnnotatedFactoryMethod;
@@ -10,11 +12,7 @@ import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWith
 import org.eclipse.yasson.internal.model.JsonbCreator;
 
 import javax.json.bind.JsonbConfig;
-
 import javax.json.spi.JsonProvider;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * Tests the {@link AnnotationIntrospector} with missing optional module "java.deskop", <br>
@@ -39,7 +37,7 @@ public class AnnotationIntrospectorWithoutOptionalModulesTest {
         String className = "java.beans.ConstructorProperties";
         try {
             Class.forName(className);
-            Assert.fail("Class [" + className + "] should not be available for this test.");
+            fail("Class [" + className + "] should not be available for this test.");
         } catch (ClassNotFoundException e) {
             // OK, as expected
         }

--- a/src/test/java/org/eclipse/yasson/internal/ClassParserTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/ClassParserTest.java
@@ -32,17 +32,9 @@ import java.util.function.Consumer;
  * @author Roman Grigoriadi
  */
 public class ClassParserTest {
-
-    private ClassParser classParser;
-    private JsonbContext jsonbContext;
-    private AnnotationIntrospector introspector;
-
-    @BeforeAll
-    public void before() {
-        jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
-        classParser = new ClassParser(jsonbContext);
-        introspector = new AnnotationIntrospector(jsonbContext);
-    }
+    private static final JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
+    private static final ClassParser classParser = new ClassParser(jsonbContext);
+    private static final AnnotationIntrospector introspector = new AnnotationIntrospector(jsonbContext);
 
     @Test
     public void testDefaultMappingFieldModifiers() {
@@ -55,7 +47,6 @@ public class ClassParserTest {
         assertFalse(model.getPropertyModel("staticString").isWritable());
         assertFalse(model.getPropertyModel("transientString").isReadable());
         assertFalse(model.getPropertyModel("transientString").isWritable());
-
     }
 
     @Test
@@ -78,5 +69,4 @@ public class ClassParserTest {
         model.getPropertyModel("getterWithoutFieldValue").setValue(object, "ACCEPTED_VALUE");
         assertEquals("ACCEPTED_VALUE", accepted.get());
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/internal/ClassParserTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/ClassParserTest.java
@@ -13,19 +13,18 @@
 
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.modifiers.model.FieldModifiersClass;
 import org.eclipse.yasson.defaultmapping.modifiers.model.MethodModifiersClass;
 import org.eclipse.yasson.internal.model.ClassModel;
 import org.eclipse.yasson.internal.model.JsonbAnnotatedElement;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.JsonbConfig;
 import javax.json.spi.JsonProvider;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-
-import static org.junit.Assert.*;
 
 /**
  * Test for ClassParser component.
@@ -35,12 +34,10 @@ import static org.junit.Assert.*;
 public class ClassParserTest {
 
     private ClassParser classParser;
-
     private JsonbContext jsonbContext;
-
     private AnnotationIntrospector introspector;
 
-    @Before
+    @BeforeAll
     public void before() {
         jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
         classParser = new ClassParser(jsonbContext);

--- a/src/test/java/org/eclipse/yasson/internal/CollectionsWithJavaBaseTypesTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/CollectionsWithJavaBaseTypesTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.yasson.internal;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbConfig;
@@ -57,13 +57,13 @@ public class CollectionsWithJavaBaseTypesTest {
         })).build();
 
         String expected = "{\"dates\":[\"2020-01-01\",null],\"innerArrayInts\":[[1,null]],\"listOfListsOfIntegers\":[[0,1,null]],\"names\":[\"First\",\"second\",null],\"optionalInts\":[2147483647,null]}";
-        Assert.assertEquals(expected, jsonb.toJson(properties));
+        assertEquals(expected, jsonb.toJson(properties));
 
         JavaBasePropertiesInContainer result = jsonb.fromJson(expected, JavaBasePropertiesInContainer.class);
-        Assert.assertEquals(properties.getNames(), result.getNames());
-        Assert.assertEquals(properties.getOptionalInts(), result.getOptionalInts());
-        Assert.assertEquals(properties.getListOfListsOfIntegers(), result.getListOfListsOfIntegers());
-        Assert.assertArrayEquals(properties.getInnerArrayInts(), result.getInnerArrayInts());
+        assertEquals(properties.getNames(), result.getNames());
+        assertEquals(properties.getOptionalInts(), result.getOptionalInts());
+        assertEquals(properties.getListOfListsOfIntegers(), result.getListOfListsOfIntegers());
+        assertArrayEquals(properties.getInnerArrayInts(), result.getInnerArrayInts());
     }
 
     public static final class JavaBasePropertiesInContainer {

--- a/src/test/java/org/eclipse/yasson/internal/CollectionsWithJavaBaseTypesTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/CollectionsWithJavaBaseTypesTest.java
@@ -21,7 +21,8 @@ public class CollectionsWithJavaBaseTypesTest {
     public void testSimple() {
         JavaBasePropertiesInContainer properties = new JavaBasePropertiesInContainer();
         properties.setNames(Arrays.asList("First", "second", null));
-        for(int i=0; i<3; i++) {
+        
+        for(int i = 0; i < 3; i++) {
             List<Integer> integerList = new ArrayList<>();
             integerList.add(0);
             integerList.add(1);

--- a/src/test/java/org/eclipse/yasson/internal/ConstructorPropertiesAnnotationIntrospectorTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/ConstructorPropertiesAnnotationIntrospectorTest.java
@@ -1,10 +1,11 @@
 package org.eclipse.yasson.internal;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertCreatedInstanceContainsAllParameters;
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestAsserts.assertParameters;
 import static org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.constructorsOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithConstructorPropertiesAnnotation;
 import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWithJsonbCreatorAnnotatedConstructor;
@@ -16,25 +17,17 @@ import org.eclipse.yasson.internal.AnnotationIntrospectorTestFixtures.ObjectWith
 import org.eclipse.yasson.internal.model.JsonbCreator;
 
 import javax.json.bind.JsonbConfig;
-
 import javax.json.spi.JsonProvider;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ConstructorPropertiesAnnotationIntrospectorTest {
 
-    private JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
-    private AnnotationFinder constructorPropertiesFinder = AnnotationFinder.findConstructorProperties();
+    private final JsonbContext jsonbContext = new JsonbContext(new JsonbConfig(), JsonProvider.provider());
+    private final AnnotationFinder constructorPropertiesFinder = AnnotationFinder.findConstructorProperties();
 
     /**
      * class under test.
      */
     private ConstructorPropertiesAnnotationIntrospector instrospector = new ConstructorPropertiesAnnotationIntrospector(jsonbContext, constructorPropertiesFinder);
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testObjectShouldBeCreateableFromConstructorPropertiesAnnotatedConstructor() {

--- a/src/test/java/org/eclipse/yasson/internal/ReflectionUtilsTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/ReflectionUtilsTest.java
@@ -1,14 +1,12 @@
 package org.eclipse.yasson.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/internal/ReflectionUtilsTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/ReflectionUtilsTest.java
@@ -43,7 +43,7 @@ public class ReflectionUtilsTest {
         assertFalse(ReflectionUtils.isResolvedType(getFieldType("unresolvedWildcardField")));
     }
 
-    private Type getFieldType(String fieldName) {
+    private static Type getFieldType(String fieldName) {
         try {
             Field field = Types.class.getField(fieldName);
             return field.getGenericType();

--- a/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
@@ -15,7 +15,6 @@ package org.eclipse.yasson.internal.cdi;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory;
 
@@ -42,7 +41,9 @@ public class CdiInjectionTest {
         WeldManager weldManager = new WeldManager();
         weldManager.startWeld(CalledMethods.class, CdiTestService.class, HelloService1.class, HelloService2.class);
 
-        final String result = defaultJsonb.toJson(new AdaptedPojo());
+        Jsonb jsonb = JsonbBuilder.create();
+        final String result = jsonb.toJson(new AdaptedPojo());
+        jsonb.close();
         assertEquals("{\"adaptedValue1\":1111,\"adaptedValue2\":1001,\"adaptedValue3\":1010}", result);
 
         //HelloService1 is @ApplicationScoped
@@ -77,7 +78,8 @@ public class CdiInjectionTest {
 
         String result;
         try {
-            result = defaultJsonb.toJson(new AdaptedPojo());
+            Jsonb jsonb = JsonbBuilder.create();
+            result = jsonb.toJson(new AdaptedPojo());
         } finally {
             context.unbind(JsonbComponentInstanceCreatorFactory.BEAN_MANAGER_NAME);
         }
@@ -104,9 +106,11 @@ public class CdiInjectionTest {
         assertEquals("{\"adaptedValue3\":1010}", result);
     }
 
-    private static CalledMethods getCalledMethods() {
+    private CalledMethods getCalledMethods() {
         final BeanManager beanManager = CDI.current().getBeanManager();
         final Bean<?> resolve = beanManager.resolve(beanManager.getBeans(CalledMethods.class));
         return (CalledMethods) beanManager.getReference(resolve, CalledMethods.class, beanManager.createCreationalContext(resolve));
     }
+
+
 }

--- a/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
@@ -13,8 +13,10 @@
 
 package org.eclipse.yasson.internal.cdi;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory;
-import org.junit.Test;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -28,8 +30,6 @@ import javax.naming.NamingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Map;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/cdi/CdiInjectionTest.java
@@ -15,6 +15,7 @@ package org.eclipse.yasson.internal.cdi;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.internal.components.JsonbComponentInstanceCreatorFactory;
 
@@ -41,9 +42,7 @@ public class CdiInjectionTest {
         WeldManager weldManager = new WeldManager();
         weldManager.startWeld(CalledMethods.class, CdiTestService.class, HelloService1.class, HelloService2.class);
 
-        Jsonb jsonb = JsonbBuilder.create();
-        final String result = jsonb.toJson(new AdaptedPojo());
-        jsonb.close();
+        final String result = defaultJsonb.toJson(new AdaptedPojo());
         assertEquals("{\"adaptedValue1\":1111,\"adaptedValue2\":1001,\"adaptedValue3\":1010}", result);
 
         //HelloService1 is @ApplicationScoped
@@ -78,8 +77,7 @@ public class CdiInjectionTest {
 
         String result;
         try {
-            Jsonb jsonb = JsonbBuilder.create();
-            result = jsonb.toJson(new AdaptedPojo());
+            result = defaultJsonb.toJson(new AdaptedPojo());
         } finally {
             context.unbind(JsonbComponentInstanceCreatorFactory.BEAN_MANAGER_NAME);
         }
@@ -106,11 +104,9 @@ public class CdiInjectionTest {
         assertEquals("{\"adaptedValue3\":1010}", result);
     }
 
-    private CalledMethods getCalledMethods() {
+    private static CalledMethods getCalledMethods() {
         final BeanManager beanManager = CDI.current().getBeanManager();
         final Bean<?> resolve = beanManager.resolve(beanManager.getBeans(CalledMethods.class));
         return (CalledMethods) beanManager.getReference(resolve, CalledMethods.class, beanManager.createCreationalContext(resolve));
     }
-
-
 }

--- a/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
@@ -13,10 +13,11 @@
 
 package org.eclipse.yasson.internal.concurrent;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.defaultmapping.specific.CustomerTest;
 import org.eclipse.yasson.defaultmapping.specific.model.Customer;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -28,8 +29,6 @@ import java.lang.reflect.Method;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
-
-import static junit.framework.TestCase.assertEquals;
 
 /**
  * Tests consistency along sharing instances of Jsonb with different JsonbConfig between threads.

--- a/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
@@ -104,14 +104,14 @@ public class MultiTenancyTest extends CustomerTest {
     /**
      * Thread pool for JSONB processing.
      */
-    private ExecutorService jsonbProcessingThreadPool;
-    private CompletionService<JsonProcessingResult<MarshallerTaskResult>> marshallingCompletion;
-    private CompletionService<JsonProcessingResult<Customer>> unmarshallingCompletion;
+    private static ExecutorService jsonbProcessingThreadPool;
+    private static CompletionService<JsonProcessingResult<MarshallerTaskResult>> marshallingCompletion;
+    private static CompletionService<JsonProcessingResult<Customer>> unmarshallingCompletion;
 
     /**
      * Executor for checking results.
      */
-    private ExecutorService resultCheckService;
+    private static ExecutorService resultCheckService;
 
     /**
      * Jsonb instances configuration initialisation.
@@ -141,7 +141,7 @@ public class MultiTenancyTest extends CustomerTest {
     }
 
     @BeforeAll
-    public void setUp() throws Exception {
+    public static void setUp() throws Exception {
         jsonbProcessingThreadPool = Executors.newFixedThreadPool(THREAD_COUNT);
         marshallingCompletion = new ExecutorCompletionService<>(jsonbProcessingThreadPool);
         unmarshallingCompletion = new ExecutorCompletionService<>(jsonbProcessingThreadPool);
@@ -172,7 +172,7 @@ public class MultiTenancyTest extends CustomerTest {
      * would be stale and results will not match.
      */
     private void submitResultCheckingTasks() {
-        resultCheckService.execute(new ResultChecker<MarshallerTaskResult>(marshallingCompletion) {
+        resultCheckService.execute(new ResultChecker<>(marshallingCompletion) {
             @Override
             protected void checkResult(JsonProcessingResult<MarshallerTaskResult> result) {
                 MarshallerTaskResult marshallerResult = result.getResult();
@@ -183,7 +183,7 @@ public class MultiTenancyTest extends CustomerTest {
             }
         });
 
-        resultCheckService.execute(new ResultChecker<Customer>(unmarshallingCompletion) {
+        resultCheckService.execute(new ResultChecker<>(unmarshallingCompletion) {
             @Override
             protected void checkResult(JsonProcessingResult<Customer> result) {
                 //actual check, unmarshalled json result have all expected values.
@@ -199,7 +199,7 @@ public class MultiTenancyTest extends CustomerTest {
      * Chooses shared jsonb instance, either with default or customized key names
      * and submits marshaller an unmarshaller task for it.
      */
-    private void submitJsonbProcessingTasks() {
+    private static void submitJsonbProcessingTasks() {
         for(int i = 0; i< TOTAL_JOB_COUNT; i+=2) {
             boolean even = (i % 4 == 0);
             ConfigurationType jsonbConfiguration = even ? ConfigurationType.DEFAULT : ConfigurationType.CUSTOMIZED;

--- a/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/concurrent/MultiTenancyTest.java
@@ -140,7 +140,7 @@ public class MultiTenancyTest extends CustomerTest {
         customizedJsonBinding = JsonbBuilder.create(customizedConfig);
     }
 
-    @Before
+    @BeforeAll
     public void setUp() throws Exception {
         jsonbProcessingThreadPool = Executors.newFixedThreadPool(THREAD_COUNT);
         marshallingCompletion = new ExecutorCompletionService<>(jsonbProcessingThreadPool);

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/naming/PropertyNamingStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/naming/PropertyNamingStrategyTest.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.yasson.internal.model.customization.naming;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
@@ -21,9 +22,6 @@ import javax.json.bind.JsonbConfig;
 import javax.json.bind.config.PropertyNamingStrategy;
 
 import org.eclipse.yasson.internal.model.customization.StrategiesProvider;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Tests naming strategies.

--- a/src/test/java/org/eclipse/yasson/internal/model/customization/naming/PropertyNamingStrategyTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/model/customization/naming/PropertyNamingStrategyTest.java
@@ -46,7 +46,6 @@ public class PropertyNamingStrategyTest {
         assertEquals(lowercaseUnderscoresJson, jsonb.toJson(pojo));
         NamingPojo result = jsonb.fromJson(lowercaseUnderscoresJson, NamingPojo.class);
         assertResult(result);
-
     }
 
     @Test
@@ -93,7 +92,6 @@ public class PropertyNamingStrategyTest {
 
     @Test
     public void testCaseInsensitive() {
-
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyNamingStrategy(PropertyNamingStrategy.CASE_INSENSITIVE));
         String upperCased = "{\"CAPS_UNDERSCORE_PROPERTY\":\"ghi\",\"_startingWithUnderscoreProperty\":\"def\",\"upperCasedProperty\":\"abc\"}";
         assertEquals(upperCased, jsonb.toJson(pojo));
@@ -120,11 +118,9 @@ public class PropertyNamingStrategyTest {
         assertResult(result);
     }
     
-    private void assertResult(NamingPojo result) {
+    private static void assertResult(NamingPojo result) {
         assertEquals("abc", result.upperCasedProperty);
         assertEquals("def", result._startingWithUnderscoreProperty);
         assertEquals("ghi", result.CAPS_UNDERSCORE_PROPERTY);
     }
-
-
 }

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -1,8 +1,7 @@
 package org.eclipse.yasson.internal.serializer;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -2,23 +2,17 @@ package org.eclipse.yasson.internal.serializer;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 
 public class ObjectDeserializerTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void testGetInstanceExceptionShouldContainClassNameOnMissingConstructor() {
-        expectedException.expect(JsonbException.class);
-        expectedException.expectMessage(DummyDeserializationClass.class.getName());
-
-        Jsonb jsonb = JsonbBuilder.create();
-        jsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class);
+    	assertThrows(JsonbException.class, 
+    				() -> defaultJsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class),
+    				DummyDeserializationClass.class::getName);
     }
 
     public static class DummyDeserializationClass {

--- a/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
@@ -11,13 +11,11 @@ package org.eclipse.yasson.jsonpsubstitution;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.Assertions;
-import org.eclipse.yasson.JsonBindingProvider;
 import org.eclipse.yasson.TestTypeToken;
-import org.eclipse.yasson.YassonJsonb;
 
-import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonParser;
@@ -65,21 +63,11 @@ public class PreinstantiatedJsonpTest {
 
     private Dog dog = new Dog("Falco", 4);
 
-    private YassonJsonb jsonb;
-
-    @BeforeAll
-    public void setUp() {
-        // Create Jsonb and serialize
-        JsonBindingProvider provider = new JsonBindingProvider();
-        JsonbBuilder builder = provider.create();
-        jsonb = (YassonJsonb) builder.build();
-    }
-
     @Test
     public void testPreinstantiatedJsonGeneratorAndParser() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator generator = new SuffixJsonGenerator("Best dog ever!", out);
-        jsonb.toJson(dog, generator);
+        bindingYassonJsonb.toJson(dog, generator);
         generator.close();
 
         assertEquals(EXPECTED_JSON, new String(out.toByteArray()));
@@ -91,7 +79,7 @@ public class PreinstantiatedJsonpTest {
             }
             return value;
         }, in);
-        Dog result = jsonb.fromJson(parser, Dog.class);
+        Dog result = bindingYassonJsonb.fromJson(parser, Dog.class);
 
         assertEquals("Falco, a best dog ever!", result.name);
         assertEquals(4, result.age);
@@ -111,7 +99,7 @@ public class PreinstantiatedJsonpTest {
         parser.next(); //START_OBJECT
         parser.next(); //"instance" KEY
 
-        Dog result = jsonb.fromJson(parser, Dog.class);
+        Dog result = bindingYassonJsonb.fromJson(parser, Dog.class);
 
         parser.next(); //END_OJBECT
 
@@ -127,7 +115,7 @@ public class PreinstantiatedJsonpTest {
 
         generator.writeStartObject();
         generator.writeKey("instance");
-        jsonb.toJson(dog, generator);
+        bindingYassonJsonb.toJson(dog, generator);
         generator.writeEnd();
         generator.close();
 
@@ -148,7 +136,7 @@ public class PreinstantiatedJsonpTest {
         //should be advanced further
 
         try {
-            jsonb.fromJson(parser, Dog.class);
+        	bindingYassonJsonb.fromJson(parser, Dog.class);
             fail("JsonbException not thrown");
         } catch (JsonbException e) {
             //OK, parser in inconsistent state
@@ -163,7 +151,7 @@ public class PreinstantiatedJsonpTest {
         generator.writeStartObject();
         //key not written
 
-        Assertions.shouldFail(() -> jsonb.toJson(dog, generator));
+        Assertions.shouldFail(() -> bindingYassonJsonb.toJson(dog, generator));
     }
 
     @Test
@@ -177,7 +165,7 @@ public class PreinstantiatedJsonpTest {
             }
             return value;
         }, in);
-        Wrapper<String> result = jsonb.fromJson(parser, new TestTypeToken<Wrapper<String>>() {}.getType());
+        Wrapper<String> result = bindingYassonJsonb.fromJson(parser, new TestTypeToken<Wrapper<String>>() {}.getType());
         assertEquals("Adapted string", result.getValue());
     }
 
@@ -187,9 +175,8 @@ public class PreinstantiatedJsonpTest {
         stringWrapper.setValue("String value");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JsonGenerator generator = new SuffixJsonGenerator("Appended value.", out);
-        jsonb.toJson(stringWrapper, new TestTypeToken<List<String>>(){}.getType(), generator);
+        bindingYassonJsonb.toJson(stringWrapper, new TestTypeToken<List<String>>(){}.getType(), generator);
         generator.close();
         assertEquals("{\"value\":\"String value\",\"suffix\":\"Appended value.\"}", out.toString());
     }
-
 }

--- a/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
@@ -9,13 +9,13 @@
  ******************************************************************************/
 package org.eclipse.yasson.jsonpsubstitution;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.Assertions;
 import org.eclipse.yasson.JsonBindingProvider;
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.YassonJsonb;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.json.bind.JsonbBuilder;
 import javax.json.bind.JsonbException;
@@ -24,9 +24,6 @@ import javax.json.stream.JsonParser;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class PreinstantiatedJsonpTest {
 

--- a/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonpsubstitution/PreinstantiatedJsonpTest.java
@@ -67,7 +67,7 @@ public class PreinstantiatedJsonpTest {
 
     private YassonJsonb jsonb;
 
-    @Before
+    @BeforeAll
     public void setUp() {
         // Create Jsonb and serialize
         JsonBindingProvider provider = new JsonBindingProvider();
@@ -149,7 +149,7 @@ public class PreinstantiatedJsonpTest {
 
         try {
             jsonb.fromJson(parser, Dog.class);
-            Assert.fail("JsonbException not thrown");
+            fail("JsonbException not thrown");
         } catch (JsonbException e) {
             //OK, parser in inconsistent state
         }
@@ -178,7 +178,7 @@ public class PreinstantiatedJsonpTest {
             return value;
         }, in);
         Wrapper<String> result = jsonb.fromJson(parser, new TestTypeToken<Wrapper<String>>() {}.getType());
-        Assert.assertEquals("Adapted string", result.getValue());
+        assertEquals("Adapted string", result.getValue());
     }
 
     @Test
@@ -189,7 +189,7 @@ public class PreinstantiatedJsonpTest {
         JsonGenerator generator = new SuffixJsonGenerator("Appended value.", out);
         jsonb.toJson(stringWrapper, new TestTypeToken<List<String>>(){}.getType(), generator);
         generator.close();
-        Assert.assertEquals("{\"value\":\"String value\",\"suffix\":\"Appended value.\"}", out.toString());
+        assertEquals("{\"value\":\"String value\",\"suffix\":\"Appended value.\"}", out.toString());
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/jsonstructure/JsonGeneratorToStructureAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonstructure/JsonGeneratorToStructureAdapterTest.java
@@ -2,6 +2,7 @@ package org.eclipse.yasson.jsonstructure;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.YassonJsonb;
 
@@ -19,8 +20,6 @@ import java.util.List;
 
 public class JsonGeneratorToStructureAdapterTest {
 
-    private final YassonJsonb jsonb = (YassonJsonb) JsonbBuilder.create();
-
     @Test
     public void testSimplePojo() {
         Pojo pojo = new Pojo();
@@ -28,7 +27,7 @@ public class JsonGeneratorToStructureAdapterTest {
         pojo.setLongProperty(10L);
         pojo.setStringProperty("String value");
 
-        JsonObject result = (JsonObject) jsonb.toJsonStructure(pojo);
+        JsonObject result = (JsonObject) yassonJsonb.toJsonStructure(pojo);
 
         assertEquals("String value", getString(result.get("stringProperty")));
         JsonValue bigDecimalProperty = result.get("bigDecimalProperty");
@@ -49,7 +48,7 @@ public class JsonGeneratorToStructureAdapterTest {
         pojo.getInner().setInnerFirst("First");
         pojo.getInner().setInnerSecond("Second");
 
-        JsonObject result = (JsonObject) jsonb.toJsonStructure(pojo, Pojo.class);
+        JsonObject result = (JsonObject) yassonJsonb.toJsonStructure(pojo, Pojo.class);
         assertEquals("String value", getString(result.get("stringProperty")));
         JsonValue bigDecimalProperty = result.get("bigDecimalProperty");
         assertTrue(bigDecimalProperty instanceof JsonNumber);
@@ -62,7 +61,6 @@ public class JsonGeneratorToStructureAdapterTest {
         assertEquals(JsonValue.ValueType.OBJECT, inner.getValueType());
         assertEquals("First", ((JsonObject)inner).getString("innerFirst"));
         assertEquals("Second", ((JsonObject)inner).getString("innerSecond"));
-
     }
 
     @Test
@@ -74,7 +72,7 @@ public class JsonGeneratorToStructureAdapterTest {
         objList.add(Boolean.TRUE);
         objList.add(null);
 
-        JsonArray result = (JsonArray) jsonb.toJsonStructure(objList);
+        JsonArray result = (JsonArray) yassonJsonb.toJsonStructure(objList);
         assertEquals("First", result.getString(0));
         assertEquals(10L, result.getJsonNumber(1).longValueExact());
         assertEquals(BigDecimal.ONE, result.getJsonNumber(2).bigDecimalValue());
@@ -92,7 +90,7 @@ public class JsonGeneratorToStructureAdapterTest {
         pojo.getBigDecimals().add(BigDecimal.TEN);
         pojo.getBooleans().add(Boolean.TRUE);
 
-        JsonObject result = (JsonObject) jsonb.toJsonStructure(pojo);
+        JsonObject result = (JsonObject) yassonJsonb.toJsonStructure(pojo);
         assertEquals(JsonValue.ValueType.ARRAY, result.get("strings").getValueType());
         assertEquals(JsonValue.ValueType.ARRAY, result.get("bigDecimals").getValueType());
         assertEquals(JsonValue.ValueType.ARRAY, result.get("booleans").getValueType());
@@ -112,7 +110,7 @@ public class JsonGeneratorToStructureAdapterTest {
         inner.add(null);
         outer.add(inner);
 
-        JsonArray result = (JsonArray) jsonb.toJsonStructure(outer);
+        JsonArray result = (JsonArray) yassonJsonb.toJsonStructure(outer);
         assertEquals(JsonValue.ValueType.ARRAY, result.get(0).getValueType());
         JsonArray resultInner = result.getJsonArray(0);
 
@@ -140,7 +138,7 @@ public class JsonGeneratorToStructureAdapterTest {
         assertEquals("Second value", ((JsonString) inner.get("second")).getString());
     }
 
-    private String getString(JsonValue value) {
+    private static String getString(JsonValue value) {
         if (value instanceof JsonString) {
             return ((JsonString) value).getString();
         }

--- a/src/test/java/org/eclipse/yasson/jsonstructure/JsonGeneratorToStructureAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonstructure/JsonGeneratorToStructureAdapterTest.java
@@ -1,7 +1,9 @@
 package org.eclipse.yasson.jsonstructure;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.YassonJsonb;
-import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonNumber;
@@ -14,9 +16,6 @@ import javax.json.bind.JsonbConfig;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class JsonGeneratorToStructureAdapterTest {
 

--- a/src/test/java/org/eclipse/yasson/jsonstructure/JsonStructureToParserAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonstructure/JsonStructureToParserAdapterTest.java
@@ -2,6 +2,7 @@ package org.eclipse.yasson.jsonstructure;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.YassonJsonb;
@@ -19,9 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 public class JsonStructureToParserAdapterTest {
-
-    private final YassonJsonb jsonb = (YassonJsonb) JsonbBuilder.create();
-
     private final JsonProvider jsonProvider = JsonProvider.provider();
 
     @Test
@@ -31,7 +29,7 @@ public class JsonStructureToParserAdapterTest {
         objectBuilder.add("bigDecimalProperty", new BigDecimal("1.1"));
         objectBuilder.add("longProperty", 10L);
         JsonObject jsonObject = objectBuilder.build();
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
         assertEquals("value 1", result.getStringProperty());
         assertEquals(new BigDecimal("1.1"), result.getBigDecimalProperty());
         assertEquals(Long.valueOf(10), result.getLongProperty());
@@ -44,7 +42,7 @@ public class JsonStructureToParserAdapterTest {
         objectBuilder.addNull("bigDecimalProperty");
         objectBuilder.add("longProperty", 10L);
         JsonObject jsonObject = objectBuilder.build();
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
         assertNull(result.getStringProperty());
         assertNull(result.getBigDecimalProperty());
         assertEquals(Long.valueOf(10), result.getLongProperty());
@@ -63,7 +61,7 @@ public class JsonStructureToParserAdapterTest {
         objectBuilder.add("bigDecimalProperty", new BigDecimal("1.1"));
         objectBuilder.add("longProperty", 10L);
         JsonObject jsonObject = objectBuilder.build();
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
 
         assertEquals("value 1", result.getStringProperty());
         assertEquals(new BigDecimal("1.1"), result.getBigDecimalProperty());
@@ -86,7 +84,7 @@ public class JsonStructureToParserAdapterTest {
         objectBuilder.add("inner", innerBuilder.build());
 
         JsonObject jsonObject = objectBuilder.build();
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
 
         assertEquals("value 1", result.getStringProperty());
         assertEquals(new BigDecimal("1.1"), result.getBigDecimalProperty());
@@ -100,7 +98,7 @@ public class JsonStructureToParserAdapterTest {
     public void testEmptyJsonObject() {
         JsonObjectBuilder objectBuilder = jsonProvider.createObjectBuilder();
         JsonObject jsonObject = objectBuilder.build();
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
         assertNull(result.getStringProperty());
         assertNull(result.getBigDecimalProperty());
         assertNull(result.getLongProperty());
@@ -117,7 +115,7 @@ public class JsonStructureToParserAdapterTest {
 
         JsonObject jsonObject = objectBuilder.build();
 
-        Pojo result = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo result = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
         assertNull(result.getStringProperty());
         assertNull(result.getBigDecimalProperty());
         assertNull(result.getLongProperty());
@@ -132,7 +130,7 @@ public class JsonStructureToParserAdapterTest {
         JsonArrayBuilder arrayBuilder = jsonProvider.createArrayBuilder();
         arrayBuilder.add(BigDecimal.TEN).add("String value").addNull();
         JsonArray jsonArray = arrayBuilder.build();
-        List result = jsonb.fromJsonStructure(jsonArray, ArrayList.class);
+        List result = yassonJsonb.fromJsonStructure(jsonArray, ArrayList.class);
         assertEquals(3, result.size());
         assertEquals(BigDecimal.TEN, result.get(0));
         assertEquals("String value", result.get(1));
@@ -155,7 +153,7 @@ public class JsonStructureToParserAdapterTest {
         pojoBuilder.add("booleans", blnBuilder.build());
 
         JsonObject jsonObject = pojoBuilder.build();
-        Pojo pojo = jsonb.fromJsonStructure(jsonObject, Pojo.class);
+        Pojo pojo = yassonJsonb.fromJsonStructure(jsonObject, Pojo.class);
 
         assertEquals(1, pojo.getBigDecimals().size());
         assertEquals(1, pojo.getStrings().size());
@@ -172,7 +170,7 @@ public class JsonStructureToParserAdapterTest {
 
         JsonArray jsonArray = arrayBuilder.build();
 
-        ArrayList result = jsonb.fromJsonStructure(jsonArray, ArrayList.class);
+        ArrayList result = yassonJsonb.fromJsonStructure(jsonArray, ArrayList.class);
         assertEquals(2, result.size());
         assertEquals(BigDecimal.TEN, result.get(0));
         assertTrue(result.get(1) instanceof List);
@@ -198,7 +196,7 @@ public class JsonStructureToParserAdapterTest {
 
         JsonArray rootArray = arrayBuilder.build();
 
-        List<Object> result = jsonb.fromJsonStructure(rootArray, new TestTypeToken<List<Pojo>>(){}.getType());
+        List<Object> result = yassonJsonb.fromJsonStructure(rootArray, new TestTypeToken<List<Pojo>>(){}.getType());
         assertTrue(result.get(0) instanceof Pojo);
         Pojo pojo = (Pojo) result.get(0);
         assertNotNull(pojo);
@@ -229,7 +227,7 @@ public class JsonStructureToParserAdapterTest {
 
         JsonArray rootArray = arrayBuilder.build();
 
-        List<Object> result = jsonb.fromJsonStructure(rootArray, new TestTypeToken<List<Object>>(){}.getType());
+        List<Object> result = yassonJsonb.fromJsonStructure(rootArray, new TestTypeToken<List<Object>>(){}.getType());
         assertEquals(new BigDecimal("10"), result.get(0));
         assertTrue(result.get(1) instanceof Map);
         Map pojo = (Map) result.get(1);

--- a/src/test/java/org/eclipse/yasson/jsonstructure/JsonStructureToParserAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/jsonstructure/JsonStructureToParserAdapterTest.java
@@ -1,8 +1,10 @@
 package org.eclipse.yasson.jsonstructure;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.YassonJsonb;
-import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
@@ -15,11 +17,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class JsonStructureToParserAdapterTest {
 

--- a/src/test/java/org/eclipse/yasson/serializers/MapToEntriesArraySerializerTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/MapToEntriesArraySerializerTest.java
@@ -12,10 +12,8 @@
  ******************************************************************************/
 package org.eclipse.yasson.serializers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.StringReader;
 import java.lang.reflect.ParameterizedType;
@@ -36,7 +34,6 @@ import javax.json.bind.JsonbConfig;
 
 import org.eclipse.yasson.serializers.model.Pokemon;
 import org.eclipse.yasson.serializers.model.Trainer;
-import org.junit.Test;
 
 /**
  * Test various use-cases with {@code Map} serializer and de-serializer which

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -16,6 +16,7 @@ package org.eclipse.yasson.serializers;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.eclipse.yasson.Jsonbs.*;
 
 import static java.util.Collections.singletonMap;
 
@@ -84,12 +85,11 @@ public class SerializersTest {
         crate.annotatedGenericType.value.crateStr = "inside generic";
         crate.annotatedTypeOverriddenOnProperty = new AnnotatedWithSerializerType();
         crate.annotatedTypeOverriddenOnProperty.value = "def";
-        final Jsonb jsonb = JsonbBuilder.create();
         String expected = "{\"annotatedGenericType\":{\"generic\":{\"crate_str\":\"inside generic\"}},\"annotatedType\":{\"valueField\":\"replaced value\"},\"annotatedTypeOverriddenOnProperty\":{\"valueField\":\"overridden value\"},\"crateBigDec\":10,\"crate_str\":\"crateStr\"}";
 
-        assertEquals(expected, jsonb.toJson(crate));
+        assertEquals(expected, defaultJsonb.toJson(crate));
 
-        Crate result = jsonb.fromJson(expected, Crate.class);
+        Crate result = defaultJsonb.fromJson(expected, Crate.class);
         assertEquals("replaced value", result.annotatedType.value);
         assertEquals("overridden value", result.annotatedTypeOverriddenOnProperty.value);
         assertEquals("inside generic", result.annotatedGenericType.value.crateStr);
@@ -100,12 +100,11 @@ public class SerializersTest {
     public void testClassLevelAnnotationOnRoot() {
         AnnotatedWithSerializerType annotatedType = new AnnotatedWithSerializerType();
         annotatedType.value = "abc";
-        final Jsonb jsonb = JsonbBuilder.create();
         String expected = "{\"valueField\":\"replaced value\"}";
 
-        assertEquals(expected, jsonb.toJson(annotatedType));
+        assertEquals(expected, defaultJsonb.toJson(annotatedType));
 
-        AnnotatedWithSerializerType result = jsonb.fromJson(expected, AnnotatedWithSerializerType.class);
+        AnnotatedWithSerializerType result = defaultJsonb.fromJson(expected, AnnotatedWithSerializerType.class);
         assertEquals("replaced value", result.value);
 
     }
@@ -115,12 +114,11 @@ public class SerializersTest {
         AnnotatedGenericWithSerializerType<Crate> annotatedType = new AnnotatedGenericWithSerializerType<>();
         annotatedType.value = new Crate();
         annotatedType.value.crateStr = "inside generic";
-        final Jsonb jsonb = JsonbBuilder.create();
         String expected = "{\"generic\":{\"crate_str\":\"inside generic\"}}";
 
-        assertEquals(expected, jsonb.toJson(annotatedType));
+        assertEquals(expected, defaultJsonb.toJson(annotatedType));
 
-        AnnotatedGenericWithSerializerType<Crate> result = jsonb.fromJson(expected, new AnnotatedGenericWithSerializerType<Crate>(){}.getClass().getGenericSuperclass());
+        AnnotatedGenericWithSerializerType<Crate> result = defaultJsonb.fromJson(expected, new AnnotatedGenericWithSerializerType<Crate>(){}.getClass().getGenericSuperclass());
         assertEquals("inside generic", result.value.crateStr);
 
     }
@@ -306,15 +304,15 @@ public class SerializersTest {
         container.getListInstance().add(new SimpleContainer("Test List 2"));
 
         String jsonString = jsonb.toJson(container);
-        Assert.assertEquals("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", jsonString);
+        assertEquals("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", jsonString);
 
         SimpleAnnotatedSerializedArrayContainer unmarshalledObject = jsonb.fromJson("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", SimpleAnnotatedSerializedArrayContainer.class);
 
-        Assert.assertEquals("Test String 1", unmarshalledObject.getArrayInstance()[0].getInstance());
-        Assert.assertEquals("Test String 2", unmarshalledObject.getArrayInstance()[1].getInstance());
+        assertEquals("Test String 1", unmarshalledObject.getArrayInstance()[0].getInstance());
+        assertEquals("Test String 2", unmarshalledObject.getArrayInstance()[1].getInstance());
 
-        Assert.assertEquals("Test List 1", unmarshalledObject.getListInstance().get(0).getInstance());
-        Assert.assertEquals("Test List 2", unmarshalledObject.getListInstance().get(1).getInstance());
+        assertEquals("Test List 1", unmarshalledObject.getListInstance().get(0).getInstance());
+        assertEquals("Test List 2", unmarshalledObject.getListInstance().get(1).getInstance());
     }
 
     /**
@@ -346,11 +344,11 @@ public class SerializersTest {
         String expected = "{\"firstName\":\"S\",\"lastName\":\"Connor\"}";
         String json = jsonb.toJson(author);
 
-        Assert.assertEquals(expected, json);
+        assertEquals(expected, json);
 
         Author result = jsonb.fromJson(expected, Author.class);
-        Assert.assertEquals("John", result.getFirstName());
-        Assert.assertEquals("Connor", result.getLastName());
+        assertEquals("John", result.getFirstName());
+        assertEquals("Connor", result.getLastName());
     }
 
     @Test
@@ -361,33 +359,33 @@ public class SerializersTest {
         SupertypeSerializerPojo pojo = new SupertypeSerializerPojo();
         pojo.setNumberInteger(10);
         pojo.setAnotherNumberInteger(11);
-        Assert.assertEquals("{\"anotherNumberInteger\":\"12\",\"numberInteger\":\"11\"}", jsonb.toJson(pojo));
+        assertEquals("{\"anotherNumberInteger\":\"12\",\"numberInteger\":\"11\"}", jsonb.toJson(pojo));
 
         pojo = jsonb.fromJson("{\"anotherNumberInteger\":\"12\",\"numberInteger\":\"11\"}", SupertypeSerializerPojo.class);
-        Assert.assertEquals(Integer.valueOf(10), pojo.getNumberInteger());
-        Assert.assertEquals(Integer.valueOf(11), pojo.getAnotherNumberInteger());
+        assertEquals(Integer.valueOf(10), pojo.getNumberInteger());
+        assertEquals(Integer.valueOf(11), pojo.getAnotherNumberInteger());
     }
     
     @Test
     public void testObjectDerializerWithLexOrderStrategy() {
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.LEXICOGRAPHICAL));
         Object pojo = jsonb.fromJson("{\"first\":{},\"third\":{},\"second\":{\"second\":2,\"first\":1}}", Object.class);
-        Assert.assertTrue("Pojo is not of type TreeMap", pojo instanceof TreeMap);
+        assertTrue(pojo instanceof TreeMap, "Pojo is not of type TreeMap");
         @SuppressWarnings("unchecked")
         SortedMap<String, Object> pojoAsMap = (SortedMap<String, Object>) pojo;
-        Assert.assertTrue("Pojo inner object is not of type TreeMap", pojoAsMap.get("second") instanceof TreeMap);
-        Assert.assertEquals("{\"first\":{},\"second\":{\"first\":1,\"second\":2},\"third\":{}}", jsonb.toJson(pojo));
+        assertTrue(pojoAsMap.get("second") instanceof TreeMap, "Pojo inner object is not of type TreeMap");
+        assertEquals("{\"first\":{},\"second\":{\"first\":1,\"second\":2},\"third\":{}}", jsonb.toJson(pojo));
     }
     
     @Test
     public void testObjectDerializerWithReverseOrderStrategy() {
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.REVERSE));
         Object pojo = jsonb.fromJson("{\"first\":{},\"second\":{\"first\":1,\"second\":2},\"third\":{}}", Object.class);
-        Assert.assertTrue("Pojo is not of type ReverseTreeMap", pojo instanceof ReverseTreeMap);
+        assertTrue(pojo instanceof ReverseTreeMap, "Pojo is not of type ReverseTreeMap");
         @SuppressWarnings("unchecked")
         SortedMap<String, Object> pojoAsMap = (SortedMap<String, Object>) pojo;
-        Assert.assertTrue("Pojo inner object is not of type TreeMap", pojoAsMap.get("second") instanceof TreeMap);
-        Assert.assertEquals("{\"third\":{},\"second\":{\"second\":2,\"first\":1},\"first\":{}}", jsonb.toJson(pojo));
+        assertTrue(pojoAsMap.get("second") instanceof TreeMap, "Pojo inner object is not of type TreeMap");
+        assertEquals("{\"third\":{},\"second\":{\"second\":2,\"first\":1},\"first\":{}}", jsonb.toJson(pojo));
     }
 
     @Test
@@ -396,11 +394,11 @@ public class SerializersTest {
         // ANY
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.ANY));
         Object pojo = jsonb.fromJson(json, Object.class);
-        Assert.assertTrue("Pojo is not of type HashMap with \"ANY\" strategy", pojo instanceof HashMap);
+        assertTrue(pojo instanceof HashMap, "Pojo is not of type HashMap with \"ANY\" strategy");
         // none
         jsonb = JsonbBuilder.create(new JsonbConfig());
         pojo = jsonb.fromJson(json, Object.class);
-        Assert.assertTrue("Pojo is not of type HashMap with no strategy", pojo instanceof HashMap);
+        assertTrue(pojo instanceof HashMap, "Pojo is not of type HashMap with no strategy");
     }
 
     @Test
@@ -409,22 +407,22 @@ public class SerializersTest {
 
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.ANY));
         SortedMap<?, ?> pojo = jsonb.fromJson(json, SortedMap.class);
-        Assert.assertTrue("Pojo is not of type TreeMap with \"ANY\" strategy", pojo instanceof TreeMap);
+        assertTrue(pojo instanceof TreeMap, "Pojo is not of type TreeMap with \"ANY\" strategy");
 
         jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.LEXICOGRAPHICAL));
         pojo = jsonb.fromJson(json, SortedMap.class);
-        Assert.assertTrue("Pojo is not of type TreeMap with no strategy", pojo instanceof TreeMap);
-        Assert.assertEquals("{\"first\":1,\"second\":2,\"third\":3}", jsonb.toJson(pojo));
+        assertTrue(pojo instanceof TreeMap, "Pojo is not of type TreeMap with no strategy");
+        assertEquals("{\"first\":1,\"second\":2,\"third\":3}", jsonb.toJson(pojo));
 
         jsonb = JsonbBuilder.create(new JsonbConfig().withPropertyOrderStrategy(PropertyOrderStrategy.REVERSE));
         pojo = jsonb.fromJson(json, SortedMap.class);
-        Assert.assertTrue("Pojo is not of type ReverseTreeMap with no strategy", pojo instanceof ReverseTreeMap);
-        Assert.assertEquals("{\"third\":3,\"second\":2,\"first\":1}", jsonb.toJson(pojo));
+        assertTrue(pojo instanceof ReverseTreeMap, "Pojo is not of type ReverseTreeMap with no strategy");
+        assertEquals("{\"third\":3,\"second\":2,\"first\":1}", jsonb.toJson(pojo));
 
         jsonb = JsonbBuilder.create(new JsonbConfig());
         pojo = jsonb.fromJson(json, SortedMap.class);
-        Assert.assertTrue("Pojo is not of type TreeMap with no strategy", pojo instanceof TreeMap);
-        Assert.assertEquals("{\"first\":1,\"second\":2,\"third\":3}", jsonb.toJson(pojo));
+        assertTrue(pojo instanceof TreeMap, "Pojo is not of type TreeMap with no strategy");
+        assertEquals("{\"first\":1,\"second\":2,\"third\":3}", jsonb.toJson(pojo));
     }
 
     @Test
@@ -434,14 +432,13 @@ public class SerializersTest {
         GenericPropertyPojo<String> stringPojo = new GenericPropertyPojo<>();
         stringPojo.setProperty("String property");
 
-        Jsonb jsonb = JsonbBuilder.create();
-        String numResult = jsonb.toJson(numberPojo, new TestTypeToken<GenericPropertyPojo<Number>>(){}.getType());
-        Assert.assertEquals("{\"propertyByUserSerializer\":\"Number value [10]\"}", numResult);
+        String numResult = defaultJsonb.toJson(numberPojo, new TestTypeToken<GenericPropertyPojo<Number>>(){}.getType());
+        assertEquals("{\"propertyByUserSerializer\":\"Number value [10]\"}", numResult);
 
-        String strResult = jsonb.toJson(stringPojo, new TestTypeToken<GenericPropertyPojo<String>>(){}.getType());
+        String strResult = defaultJsonb.toJson(stringPojo, new TestTypeToken<GenericPropertyPojo<String>>(){}.getType());
         // because GenericPropertyPojo is annotated to use GenericPropertyPojoSerializer, it will always be
         // used, despite the fact that the runtime type supplied does not match the serializer type
-        Assert.assertEquals("{\"propertyByUserSerializer\":\"Number value [String property]\"}", strResult);
+        assertEquals("{\"propertyByUserSerializer\":\"Number value [String property]\"}", strResult);
     }
 
     @Test
@@ -475,7 +472,7 @@ public class SerializersTest {
         String json = "[{\"stringProperty\":\"Property 1 value\"},{\"stringProperty\":\"Property 2 value\"}]";
         Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withDeserializers(new SimplePojoDeserializer()));
         SimplePojo[] result = jsonb.fromJson(json, SimplePojo[].class);
-        Assert.assertEquals(2, result.length);
+        assertEquals(2, result.length);
     }
 
     public class SimplePojoDeserializer implements JsonbDeserializer<SimplePojo> {

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.yasson.serializers;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.io.StringReader;
 import java.lang.reflect.Type;
@@ -65,8 +65,6 @@ import org.eclipse.yasson.serializers.model.SimpleAnnotatedSerializedArrayContai
 import org.eclipse.yasson.serializers.model.SimpleContainer;
 import org.eclipse.yasson.serializers.model.StringWrapper;
 import org.eclipse.yasson.serializers.model.SupertypeSerializerPojo;
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * @author Roman Grigoriadi

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -93,7 +93,6 @@ public class SerializersTest {
         assertEquals("replaced value", result.annotatedType.value);
         assertEquals("overridden value", result.annotatedTypeOverriddenOnProperty.value);
         assertEquals("inside generic", result.annotatedGenericType.value.crateStr);
-
     }
 
     @Test
@@ -106,7 +105,6 @@ public class SerializersTest {
 
         AnnotatedWithSerializerType result = defaultJsonb.fromJson(expected, AnnotatedWithSerializerType.class);
         assertEquals("replaced value", result.value);
-
     }
 
     @Test
@@ -120,7 +118,6 @@ public class SerializersTest {
 
         AnnotatedGenericWithSerializerType<Crate> result = defaultJsonb.fromJson(expected, new AnnotatedGenericWithSerializerType<Crate>(){}.getClass().getGenericSuperclass());
         assertEquals("inside generic", result.value.crateStr);
-
     }
 
     /**
@@ -147,7 +144,6 @@ public class SerializersTest {
         //set by deserializer statically
         assertEquals(new BigDecimal("123"), result.crate.crateBigDec);
         assertEquals("abc", result.crate.crateStr);
-
     }
 
     /**
@@ -198,7 +194,7 @@ public class SerializersTest {
         assertEquals(BigDecimal.TEN, result.crate.crateInner.crateInnerBigDec);
     }
 
-    private Date getExpectedDate() {
+    private static Date getExpectedDate() {
         return new Calendar.Builder().setDate(2015, 4, 14).setTimeOfDay(11, 10, 1).setTimeZone(TimeZone.getTimeZone("Z")).build().getTime();
     }
 
@@ -213,7 +209,6 @@ public class SerializersTest {
 
     @Test
     public void testAnnotations() {
-        final Jsonb jsonb = JsonbBuilder.create();
         BoxWithAnnotations box = new BoxWithAnnotations();
         box.boxStr = "Box string";
         box.secondBoxStr = "Second box string";
@@ -227,9 +222,9 @@ public class SerializersTest {
 
         String expected = "{\"boxStr\":\"Box string\",\"crate\":{\"crateStr\":\"REPLACED crate str\",\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"crateBigDec\":54321,\"date-converted\":\"2015-05-14T11:10:01Z[UTC]\"},\"secondBoxStr\":\"Second box string\"}";
 
-        assertEquals(expected, jsonb.toJson(box));
+        assertEquals(expected, defaultJsonb.toJson(box));
 
-        BoxWithAnnotations result = jsonb.fromJson(expected, BoxWithAnnotations.class);
+        BoxWithAnnotations result = defaultJsonb.fromJson(expected, BoxWithAnnotations.class);
 
         //deserialized by deserializationContext.deserialize(Class c)
         assertEquals(box.crate.crateInner.crateInnerBigDec, result.crate.crateInner.crateInnerBigDec);
@@ -281,17 +276,14 @@ public class SerializersTest {
 
     @Test
     public void testStringField() {
-        Jsonb jsonb = JsonbBuilder.create();
         StringWrapper pojo = new StringWrapper();
         pojo.strField = "abc";
-        final String result = jsonb.toJson(pojo);
+        final String result = defaultJsonb.toJson(pojo);
         assertEquals("{\"strField\":\"   abc\"}", result);
     }
 
     @Test
     public void testContainerSerializer() {
-        Jsonb jsonb = JsonbBuilder.create();
-
         SimpleAnnotatedSerializedArrayContainer container = new SimpleAnnotatedSerializedArrayContainer();
         SimpleContainer instance1 = new SimpleContainer();
         instance1.setInstance("Test String 1");
@@ -303,10 +295,10 @@ public class SerializersTest {
         container.getListInstance().add(new SimpleContainer("Test List 1"));
         container.getListInstance().add(new SimpleContainer("Test List 2"));
 
-        String jsonString = jsonb.toJson(container);
+        String jsonString = defaultJsonb.toJson(container);
         assertEquals("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", jsonString);
 
-        SimpleAnnotatedSerializedArrayContainer unmarshalledObject = jsonb.fromJson("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", SimpleAnnotatedSerializedArrayContainer.class);
+        SimpleAnnotatedSerializedArrayContainer unmarshalledObject = defaultJsonb.fromJson("{\"arrayInstance\":[{\"instance\":\"Test String 1\"},{\"instance\":\"Test String 2\"}],\"listInstance\":[{\"instance\":\"Test List 1\"},{\"instance\":\"Test List 2\"}]}", SimpleAnnotatedSerializedArrayContainer.class);
 
         assertEquals("Test String 1", unmarshalledObject.getArrayInstance()[0].getInstance());
         assertEquals("Test String 2", unmarshalledObject.getArrayInstance()[1].getInstance());
@@ -340,13 +332,12 @@ public class SerializersTest {
     @Test
     public void testAuthor() {
         Author author = new Author("Sarah", "Connor");
-        Jsonb jsonb = JsonbBuilder.create();
         String expected = "{\"firstName\":\"S\",\"lastName\":\"Connor\"}";
-        String json = jsonb.toJson(author);
+        String json = defaultJsonb.toJson(author);
 
         assertEquals(expected, json);
 
-        Author result = jsonb.fromJson(expected, Author.class);
+        Author result = defaultJsonb.fromJson(expected, Author.class);
         assertEquals("John", result.getFirstName());
         assertEquals("Connor", result.getLastName());
     }
@@ -396,8 +387,7 @@ public class SerializersTest {
         Object pojo = jsonb.fromJson(json, Object.class);
         assertTrue(pojo instanceof HashMap, "Pojo is not of type HashMap with \"ANY\" strategy");
         // none
-        jsonb = JsonbBuilder.create(new JsonbConfig());
-        pojo = jsonb.fromJson(json, Object.class);
+        pojo = defaultJsonb.fromJson(json, Object.class);
         assertTrue(pojo instanceof HashMap, "Pojo is not of type HashMap with no strategy");
     }
 
@@ -419,10 +409,9 @@ public class SerializersTest {
         assertTrue(pojo instanceof ReverseTreeMap, "Pojo is not of type ReverseTreeMap with no strategy");
         assertEquals("{\"third\":3,\"second\":2,\"first\":1}", jsonb.toJson(pojo));
 
-        jsonb = JsonbBuilder.create(new JsonbConfig());
-        pojo = jsonb.fromJson(json, SortedMap.class);
+        pojo = defaultJsonb.fromJson(json, SortedMap.class);
         assertTrue(pojo instanceof TreeMap, "Pojo is not of type TreeMap with no strategy");
-        assertEquals("{\"first\":1,\"second\":2,\"third\":3}", jsonb.toJson(pojo));
+        assertEquals("{\"first\":1,\"second\":2,\"third\":3}", defaultJsonb.toJson(pojo));
     }
 
     @Test
@@ -443,10 +432,9 @@ public class SerializersTest {
 
     @Test
     public void testSerializeMapWithNulls() {
-        Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withNullValues(Boolean.TRUE));
-        assertEquals("{\"null\":null}", jsonb.toJson(singletonMap(null, null)));
-        assertEquals("{\"key\":null}", jsonb.toJson(singletonMap("key", null)));
-        assertEquals("{\"null\":\"value\"}", jsonb.toJson(singletonMap(null, "value")));
+        assertEquals("{\"null\":null}", nullableJsonb.toJson(singletonMap(null, null)));
+        assertEquals("{\"key\":null}", nullableJsonb.toJson(singletonMap("key", null)));
+        assertEquals("{\"null\":\"value\"}", nullableJsonb.toJson(singletonMap(null, "value")));
     }
 
     /**
@@ -498,7 +486,7 @@ public class SerializersTest {
         }
     }
 
-    private Box createPojoWithDates() {
+    private static Box createPojoWithDates() {
         Date date = getExpectedDate();
         Box box = createPojo();
         box.crate.date = date;
@@ -506,7 +494,7 @@ public class SerializersTest {
         return box;
     }
 
-    private Box createPojo() {
+    private static Box createPojo() {
         Box box = new Box();
         box.boxStr = "Box string";
         box.crate = new Crate();
@@ -522,12 +510,10 @@ public class SerializersTest {
         return box;
     }
 
-    private CrateInner createCrateInner(String name) {
+    private static CrateInner createCrateInner(String name) {
         final CrateInner crateInner = new CrateInner();
         crateInner.crateInnerStr = name;
         crateInner.crateInnerBigDec = BigDecimal.TEN;
         return crateInner;
     }
-
-
 }

--- a/src/test/java/org/eclipse/yasson/serializers/model/AnnotatedGenericWithSerializerTypeDeserializer.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/AnnotatedGenericWithSerializerTypeDeserializer.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.yasson.serializers.model;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import javax.json.bind.serializer.DeserializationContext;
 import javax.json.bind.serializer.JsonbDeserializer;
 import javax.json.stream.JsonParser;
 import javax.json.stream.JsonParser.Event;
-
-import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;


### PR DESCRIPTION
- Unify junit imports:
   - 1 normal import for org.junit.jupiter.api
   - 1 static import for org.junit.jupiter.api.Assertions
- Merge most of the jsonb instances:
   - 1 static import for org.eclipse.yasson.Jsonbs
- Update junit dependencies to Junit Jupiter 5.5.2
   - 1 dependency for junit-jupiter-api
   - 1 dependency for junit-jupiter-engine
- Remove some unnecessary whitespace in some tests.
- No changes in the behavior of the tests.
- Tried not to change model classes.
- All(426) tests seem to be passing at least for me.

JUnit notes:
- Started using AssertThrows instead of the old expected exception mechanism.
- Had to swap around arguments in AssertEquals where a custom message was specified.