### PR TITLE
Don't use reflection when possible

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/model/ClassModel.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/ClassModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.json.bind.config.PropertyNamingStrategy;
@@ -37,7 +38,9 @@ public class ClassModel {
 
     private final ClassModel parentClassModel;
 
-    private final Constructor<?> defaultConstructor;
+    private final AtomicBoolean isInitialized = new AtomicBoolean(false);
+
+    private Constructor<?> defaultConstructor;
 
     /**
      * A map of all class properties, including properties from superclasses. Used to access by name.
@@ -77,7 +80,6 @@ public class ClassModel {
         this.classCustomization = customization;
         this.parentClassModel = parentClassModel;
         this.propertyNamingStrategy = propertyNamingStrategy;
-        this.defaultConstructor = ReflectionUtils.getDefaultConstructor(clazz, false);
         setProperties(new ArrayList<>());
     }
 
@@ -183,6 +185,13 @@ public class ClassModel {
      * @return default constructor
      */
     public Constructor<?> getDefaultConstructor() {
+        // Lazy-loads the default constructor to avoid Java 9+ "Illegal reflective access" warnings where possible.
+        // Example: Deserialization into Map won't use this constructor, and therefore never needs to call this method.
+        // Note: Null is a valid result and needs to be cached.
+        if (!isInitialized.get()) {
+            defaultConstructor = ReflectionUtils.getDefaultConstructor(clazz, false);
+            isInitialized.set(true);
+        }
         return defaultConstructor;
     }
 }


### PR DESCRIPTION
Assume the following code:

    Map<String, Object> deserialized = jsonb.fromJson(json, Map.class);

It produces the following in the console, on Java 9+:

    WARNING: An illegal reflective access operation has occurred
    WARNING: Illegal reflective access by org.eclipse.yasson.internal.ReflectionUtils (file:/home/triceo/.m2/repository/org/eclipse/yasson/1.0.7/yasson-1.0.7.jar) to constructor java.util.AbstractMap()
    WARNING: Please consider reporting this to the maintainers of org.eclipse.yasson.internal.ReflectionUtils
    WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
    WARNING: All illegal access operations will be denied in a future release

With this PR, it no longer happens.

Ideally, this would make its way both into 2.x and 1.x.