### PR TITLE
Search for custom serializers/deserializers/adapters in a deterministic way

### DIFF
--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -12,11 +12,13 @@
 
 package org.eclipse.yasson.serializers;
 
-import org.junit.jupiter.api.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.eclipse.yasson.Jsonbs.*;
-
 import static java.util.Collections.singletonMap;
+import static org.eclipse.yasson.Jsonbs.defaultJsonb;
+import static org.eclipse.yasson.Jsonbs.nullableJsonb;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.lang.reflect.Type;
@@ -29,17 +31,6 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TimeZone;
 import java.util.TreeMap;
-
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbConfig;
-import jakarta.json.bind.JsonbException;
-import jakarta.json.bind.config.PropertyOrderStrategy;
-import jakarta.json.bind.serializer.DeserializationContext;
-import jakarta.json.bind.serializer.JsonbDeserializer;
-import jakarta.json.stream.JsonParser;
 
 import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.internal.model.ReverseTreeMap;
@@ -64,6 +55,21 @@ import org.eclipse.yasson.serializers.model.SimpleAnnotatedSerializedArrayContai
 import org.eclipse.yasson.serializers.model.SimpleContainer;
 import org.eclipse.yasson.serializers.model.StringWrapper;
 import org.eclipse.yasson.serializers.model.SupertypeSerializerPojo;
+import org.junit.jupiter.api.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.config.PropertyOrderStrategy;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.bind.serializer.JsonbSerializer;
+import jakarta.json.bind.serializer.SerializationContext;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonParser;
 
 /**
  * @author Roman Grigoriadi
@@ -514,4 +520,81 @@ public class SerializersTest {
         crateInner.crateInnerBigDec = BigDecimal.TEN;
         return crateInner;
     }
+    
+    public static class Foo { }
+
+    public static class Bar extends Foo { }
+    
+    public static class Baz extends Bar { }
+
+    public static class FooSerializer implements JsonbSerializer<Foo> {
+      public void serialize(Foo obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write("foo");
+      }
+    }
+
+    public static class BazSerializer implements JsonbSerializer<Baz> {
+      public void serialize(Baz obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write("baz");
+      }
+    }
+    
+    /**
+     * Test for issue: https://github.com/quarkusio/quarkus/issues/8925
+     * Ensure that if multiple customizations (serializer, deserializer, or adapter) are applied 
+     * for different types in the same class hierarchy, we use the customization for the most 
+     * specific type in the class hierarchy.
+     */
+    @Test
+    public void testSerializerMatching() {
+      Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
+          .withSerializers(new FooSerializer(), new BazSerializer()));
+      assertEquals("\"foo\"", jsonb.toJson(new Foo()));
+      // Since 'Bar' does not have its own serializer, it should use 
+      // the next serializer in the tree (FooSerializer)
+      assertEquals("\"foo\"", jsonb.toJson(new Bar()));
+      assertEquals("\"baz\"", jsonb.toJson(new Baz()));
+    }
+    
+    public static interface One { }
+    public static interface Two { }
+    public static interface Three { }
+    
+    public static class OneTwo implements One, Two { }
+    public static class OneTwoThree implements One, Two, Three { }
+    
+    public static class OneSerializer implements JsonbSerializer<One> {
+      public void serialize(One obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write("one");
+      }
+    }
+    
+    public static class TwoSerializer implements JsonbSerializer<Two> {
+      public void serialize(Two obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write("two");
+      }
+    }
+    
+    public static class ThreeSerializer implements JsonbSerializer<Three> {
+      public void serialize(Three obj, JsonGenerator generator, SerializationContext ctx) {
+        generator.write("three");
+      }
+    }
+    
+    @Test
+    public void testSerializerMatchingInterfaces01() {
+      Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
+          .withSerializers(new OneSerializer(), new TwoSerializer(), new ThreeSerializer()));
+      assertEquals("\"one\"", jsonb.toJson(new OneTwo()));
+      assertEquals("\"one\"", jsonb.toJson(new OneTwoThree()));
+    }
+    
+    @Test
+    public void testSerializerMatchingInterfaces02() {
+      Jsonb jsonb = JsonbBuilder.create(new JsonbConfig()
+          .withSerializers(new ThreeSerializer(), new TwoSerializer()));
+      assertEquals("\"two\"", jsonb.toJson(new OneTwo()));
+      assertEquals("\"two\"", jsonb.toJson(new OneTwoThree()));
+    }
+    
 }


### PR DESCRIPTION
Fix for: https://github.com/quarkusio/quarkus/issues/8925

Currently Yasson stores all custom components (where "component" can be a JsonbSerailizer/JsonbDeserializer/JsonbAdapter) in a map, and discovers a matching component for a given type by simply iterating over the values in the component map and returning the first match.
This has a few issues:
1. The order we iterate over the component map is non-deterministic
2. We may find a component that matches, but there are more specific matches available

For example, consider:
```java
public class A {}
public class B extends A {}
public class C extends B {}
// Also assume that A/B/C have custom serializers
```
If a user wants to serialize a `new B();`, serializer's A or B would technically match, but serializer B would be the best choice because it is the closest match to the type being serialized.

The algorithm I'm proposing we use for matching is:
1. Check for a component that exactly matches the type `T`
2. Otherwise, iterate over all interfaces that type `T` implements and select the first matching interface
3. Otherwise, if `T` has a superclass, repeat steps (1) and (2) until `java.lang.Object` is reached
4. Otherwise, no match is found.
