### PR TITLE
Update puppycrawl version

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -78,8 +78,6 @@
 
     <module name="SuppressWarningsFilter"/>
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
         <module name="SuppressionCommentFilter">
             <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
             <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
@@ -91,8 +89,8 @@
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected"/>
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowMissingPropertyJavadoc" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowMissingParamTags" value="true"/>
         </module>
         <module name="JavadocType">
             <property name="scope" value="protected"/>

--- a/pom.xml
+++ b/pom.xml
@@ -506,7 +506,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.18</version>
+                            <version>8.29</version>
                             <exclusions>
                                 <exclusion>
                                     <groupId>com.sun</groupId>


### PR DESCRIPTION
I've been getting some security alerts about one of our dependencies used for checkstyle. I don't see any risk because it's just a build-time tool, but I figured it would be good to update just in case.

Had to slightly tweak the checkstyle.xml due to some breaking changes in upgrading to the newer version.