### PR TITLE
Update CI to run TCK properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ jobs:
     - stage: install-yasson
       script: mvn -U -C -Pstaging clean install
     - stage: tck-run
-      script: mvn -U -B -Pstaging test
+      script: cd yasson-tck && mvn -U -B -Pstaging test
 

--- a/src/main/java/org/eclipse/yasson/internal/serializer/ZoneIdTypeSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/ZoneIdTypeSerializer.java
@@ -35,6 +35,6 @@ public class ZoneIdTypeSerializer extends AbstractValueTypeSerializer<ZoneId> {
 
     @Override
     protected void serialize(ZoneId obj, JsonGenerator generator, Marshaller marshaller) {
-        generator.write(obj.normalized().getId());
+        generator.write(obj.getId());
     }
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -483,7 +483,6 @@ public class DatesTest {
     @Test
     public void testMarshalZoneId() {
         assertEquals("{\"value\":\"Europe/Prague\"}", bindingJsonb.toJson(new ScalarValueWrapper<>(ZoneId.of("Europe/Prague"))));
-        assertEquals("\"Z\"", bindingJsonb.toJson(ZoneId.of("UTC")));  // Issue #387
     }
 
     @Test

--- a/yasson-tck/pom.xml
+++ b/yasson-tck/pom.xml
@@ -39,13 +39,13 @@
     <dependency>
         <groupId>org.jboss.arquillian.container</groupId>
         <artifactId>arquillian-weld-embedded</artifactId>
-        <version>2.0.1.Final</version>
+        <version>3.0.0.Alpha1</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.jboss.weld.se</groupId>
-        <artifactId>weld-se</artifactId>
-        <version>2.4.3.Final</version>
+        <artifactId>weld-se-core</artifactId>
+        <version>4.0.0.Alpha2</version>
         <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
I realized that the travis job was running `mvn test` in the wrong directory, so it was just running the yasson unit tests a second time instead of running the TCK, oops.

After fixing that in CI, I also noticed that the JSON-B TCK is a bit out of date, since it needs to be updated from `javax.inject` --> `jakarta.inject`, which I opened a PR for here: https://github.com/eclipse-ee4j/jsonb-api/pull/247

Once the JSON-B TCK PR is merged, we should be able to re-test and merge this PR