### PR TITLE
Make java.sql dependency optional

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,7 +15,7 @@ module org.eclipse.yasson {
     requires jakarta.json.bind;
     requires static java.naming;
     requires java.logging;
-    requires java.sql;
+    requires static java.sql;
     requires static java.desktop;
     
     exports org.eclipse.yasson;

--- a/src/main/java/org/eclipse/yasson/internal/AnnotationIntrospector.java
+++ b/src/main/java/org/eclipse/yasson/internal/AnnotationIntrospector.java
@@ -760,7 +760,7 @@ public class AnnotationIntrospector {
     public JsonbAnnotatedElement<Class<?>> collectAnnotations(Class<?> clazz) {
         JsonbAnnotatedElement<Class<?>> classElement = new JsonbAnnotatedElement<>(clazz);
         
-        if (DefaultSerializers.getInstance().isKnownType(clazz)) {
+        if (DefaultSerializers.isKnownType(clazz)) {
             return classElement;
         }
 

--- a/src/main/java/org/eclipse/yasson/internal/MappingContext.java
+++ b/src/main/java/org/eclipse/yasson/internal/MappingContext.java
@@ -93,7 +93,7 @@ public class MappingContext {
                                                       customization,
                                                       parentClassModel,
                                                       jsonbContext.getConfigProperties().getPropertyNamingStrategy());
-            if (!DefaultSerializers.getInstance().isKnownType(aClass)) {
+            if (!DefaultSerializers.isKnownType(aClass)) {
                 classParser.parseProperties(newClassModel, clsElement);
             }
             return newClassModel;

--- a/src/main/java/org/eclipse/yasson/internal/model/PropertyModel.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/PropertyModel.java
@@ -161,8 +161,7 @@ public class PropertyModel implements Comparable<PropertyModel> {
         }
 
         final Class<?> propertyRawType = ReflectionUtils.getRawType(serializationType);
-        final Optional<SerializerProviderWrapper> valueSerializerProvider = DefaultSerializers.getInstance()
-                .findValueSerializerProvider(propertyRawType);
+        final Optional<SerializerProviderWrapper> valueSerializerProvider = DefaultSerializers.findValueSerializerProvider(propertyRawType);
         if (valueSerializerProvider.isPresent()) {
             return valueSerializerProvider.get().getSerializerProvider().provideSerializer(customization);
         }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractArrayDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractArrayDeserializer.java
@@ -50,7 +50,7 @@ public abstract class AbstractArrayDeserializer<T> extends AbstractContainerDese
         } else {
             componentClass = ReflectionUtils.getRawType(getRuntimeType()).getComponentType();
         }
-        if (!DefaultSerializers.getInstance().isKnownType(componentClass)) {
+        if (!DefaultSerializers.isKnownType(componentClass)) {
             componentClassModel = builder.getJsonbContext().getMappingContext().getOrCreateClassModel(componentClass);
         } else {
             componentClassModel = null;

--- a/src/main/java/org/eclipse/yasson/internal/serializer/AbstractContainerSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/AbstractContainerSerializer.java
@@ -177,7 +177,7 @@ public abstract class AbstractContainerSerializer<T> extends AbstractItem<T> imp
             builder.withWrapper(this);
             builder.withType(instanceValueType);
 
-            if (!DefaultSerializers.getInstance().isKnownType(itemClass)) {
+            if (!DefaultSerializers.isKnownType(itemClass)) {
                 //Need for class level annotations + user adapters/serializers bound to type
                 ClassModel classModel = ((Marshaller) ctx).getJsonbContext().getMappingContext().getOrCreateClassModel(itemClass);
                 builder.withCustomization(new ContainerCustomization(classModel.getClassCustomization()));

--- a/src/main/java/org/eclipse/yasson/internal/serializer/ContainerDeserializerUtils.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/ContainerDeserializerUtils.java
@@ -106,7 +106,7 @@ class ContainerDeserializerUtils {
         //TODO In contrast to serialization value type cannot change here
         Type actualValueType = ReflectionUtils.resolveType(wrapper, valueType);
         DeserializerBuilder deserializerBuilder = newUnmarshallerItemBuilder(wrapper, ctx, event).withType(actualValueType);
-        if (!DefaultSerializers.getInstance().isKnownType(ReflectionUtils.getRawType(actualValueType))) {
+        if (!DefaultSerializers.isKnownType(ReflectionUtils.getRawType(actualValueType))) {
             ClassModel classModel = ctx.getMappingContext().getOrCreateClassModel(ReflectionUtils.getRawType(actualValueType));
             deserializerBuilder.withCustomization(classModel == null ? null : classModel.getClassCustomization());
         }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DateTypeDeserializer.java
@@ -69,7 +69,7 @@ public class DateTypeDeserializer extends AbstractDateTimeDeserializer<Date> {
      * @param defaultZone This Zone will be used if no other Zone was found in the jsonValue
      * @return Parsed date on base of a java.time.ZonedDateTime
      */
-    private TemporalAccessor parseWithOrWithoutZone(String jsonValue, DateTimeFormatter formatter, ZoneId defaultZone) {
+    private static TemporalAccessor parseWithOrWithoutZone(String jsonValue, DateTimeFormatter formatter, ZoneId defaultZone) {
         try {
             // Try parsing with a Zone
             return ZonedDateTime.parse(jsonValue, formatter);

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DeserializerBuilder.java
@@ -199,7 +199,7 @@ public class DeserializerBuilder extends AbstractSerializerBuilder<DeserializerB
     }
 
     private Optional<AbstractValueTypeDeserializer<?>> getSupportedTypeDeserializer(Class<?> rawType) {
-        final Optional<? extends SerializerProviderWrapper> supportedTypeDeserializerOptional = DefaultSerializers.getInstance()
+        final Optional<? extends SerializerProviderWrapper> supportedTypeDeserializerOptional = DefaultSerializers
                 .findValueSerializerProvider(rawType);
         if (supportedTypeDeserializerOptional.isPresent()) {
             return Optional.of(supportedTypeDeserializerOptional.get().getDeserializerProvider()

--- a/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/SerializerBuilder.java
@@ -148,7 +148,7 @@ public class SerializerBuilder extends AbstractSerializerBuilder<SerializerBuild
     }
 
     private Optional<AbstractValueTypeSerializer<?>> getSupportedTypeSerializer(Class<?> rawType) {
-        final Optional<? extends SerializerProviderWrapper> supportedTypeSerializerOptional = DefaultSerializers.getInstance()
+        final Optional<? extends SerializerProviderWrapper> supportedTypeSerializerOptional = DefaultSerializers
                 .findValueSerializerProvider(rawType);
         if (supportedTypeSerializerOptional.isPresent()) {
             return Optional


### PR DESCRIPTION
- Make 'java.sql' static in module-info
- Add check in 'DefaultSerializers.java' to check if the sql module is available.
- If it's not available don't register the sql type handlers, only register a handler for 'java.util.Date'
- If it's available register all sql type handlers, also register 'java.util.Date' to use the 'java.sql.Date'-s serializer (SqlDateTypeSerializer) to keep compatibility.
- Refactor DefaultSerializers.java

Motivation: 'java.sql' is a quite big module. (It has a dependency on 'java.xml', which is over 4 megabytes). Not all applications need it.
If an application already has 'require java.sql' everything works like it used to.
If an application doesn't have 'requires java.sql' the sql type registration paths are skipped.