### PR TITLE
require java.xml directly so that java.desktop must not be available

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@ module org.eclipse.yasson {
     requires jakarta.json;
     requires jakarta.json.bind;
     requires java.logging;
-    requires java.xml;
+    requires static java.xml;
     requires static java.naming;
     requires static java.sql;
     requires static java.desktop;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module org.eclipse.yasson {
     requires jakarta.json;
     requires jakarta.json.bind;
     requires java.logging;
+    requires java.xml;
     requires static java.naming;
     requires static java.sql;
     requires static java.desktop;

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
@@ -142,9 +142,11 @@ public class DefaultSerializers {
                         new SerializerProviderWrapper(BigDecimalTypeSerializer::new, BigDecimalTypeDeserializer::new));
         serializers.put(ZoneOffset.class,
                         new SerializerProviderWrapper(ZoneOffsetTypeSerializer::new, ZoneOffsetTypeDeserializer::new));
-        serializers.put(XMLGregorianCalendar.class,
-                        new SerializerProviderWrapper(XMLGregorianCalendarTypeSerializer::new,
-                                                      XMLGregorianCalendarTypeDeserializer::new));
+        if(isClassAvailable("javax.xml.datatype.XMLGregorianCalendar")) {
+            serializers.put(XMLGregorianCalendar.class,
+                    new SerializerProviderWrapper(XMLGregorianCalendarTypeSerializer::new,
+                                                  XMLGregorianCalendarTypeDeserializer::new));        	
+        }
         serializers.put(YearMonth.class,
                         new SerializerProviderWrapper(YearMonthTypeSerializer::new, YearMonthTypeDeserializer::new));
         serializers.put(MonthDay.class,

--- a/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/DefaultSerializers.java
@@ -142,11 +142,13 @@ public class DefaultSerializers {
                         new SerializerProviderWrapper(BigDecimalTypeSerializer::new, BigDecimalTypeDeserializer::new));
         serializers.put(ZoneOffset.class,
                         new SerializerProviderWrapper(ZoneOffsetTypeSerializer::new, ZoneOffsetTypeDeserializer::new));
-        if(isClassAvailable("javax.xml.datatype.XMLGregorianCalendar")) {
+        
+        if (isClassAvailable("javax.xml.datatype.XMLGregorianCalendar")) {
             serializers.put(XMLGregorianCalendar.class,
                     new SerializerProviderWrapper(XMLGregorianCalendarTypeSerializer::new,
-                                                  XMLGregorianCalendarTypeDeserializer::new));        	
+                                                  XMLGregorianCalendarTypeDeserializer::new));
         }
+        
         serializers.put(YearMonth.class,
                         new SerializerProviderWrapper(YearMonthTypeSerializer::new, YearMonthTypeDeserializer::new));
         serializers.put(MonthDay.class,


### PR DESCRIPTION
fixes #490 