### PR TITLE
Fix #559: Only consider provided runtimeType for root serialization context

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/SerializationContextImpl.java
+++ b/src/main/java/org/eclipse/yasson/internal/SerializationContextImpl.java
@@ -192,9 +192,16 @@ public class SerializationContextImpl extends ProcessingContext implements Seria
      * @param generator JSON generator.
      */
     public <T> void serializeObject(T root, JsonGenerator generator) {
-        Type type = runtimeType == null ? (root == null ? Object.class : root.getClass()) : runtimeType;
+        Type type = determineSerializationType(root);
         final ModelSerializer rootSerializer = getRootSerializer(type);
         rootSerializer.serialize(root, generator, this);
+    }
+
+    private <T> Type determineSerializationType(T root) {
+        if (isRoot() && runtimeType != null) {
+            return runtimeType;
+        }
+        return root == null ? Object.class : root.getClass();
     }
 
     public ModelSerializer getRootSerializer(Type type) {

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -180,6 +180,23 @@ public class SerializersTest {
         assertEquals(pojo.crate.crateInner.crateInnerBigDec, result.crate.crateInner.crateInnerBigDec);
     }
 
+    @Test
+    public void testSerializerSerializationOfTypeWithExplicitType() {
+        JsonbConfig config = new JsonbConfig().withSerializers(new CrateSerializer());
+        Jsonb jsonb = JsonbBuilder.create(config);
+        String expected = "{\"boxStr\":\"Box string\",\"crate\":{\"crateStr\":\"REPLACED crate str\",\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"crateBigDec\":54321},\"secondBoxStr\":\"Second box string\"}";
+        Box pojo = createPojo();
+
+        assertEquals(expected, jsonb.toJson(pojo, Box.class));
+
+        Box result = jsonb.fromJson(expected, Box.class);
+        assertEquals(new BigDecimal("54321"), result.crate.crateBigDec);
+        //result.crate.crateStr is mapped to crate_str by jsonb property
+        assertNull(result.crate.crateStr);
+        assertEquals(pojo.crate.crateInner.crateInnerStr, result.crate.crateInner.crateInnerStr);
+        assertEquals(pojo.crate.crateInner.crateInnerBigDec, result.crate.crateInner.crateInnerBigDec);
+    }
+
     /**
      * Tests jsonb type conversion, including property customization.
      */


### PR DESCRIPTION
Attempt at fixing #559 -- runtime Type should be IMO only effective for root context. The double-ternary expression got quite unreadable with addition of `isRoot`, so I extracted that.