### PR TITLE
NPE when serializing a Timestamp field with custom date-time formatter

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -14,7 +14,9 @@ package org.eclipse.yasson.internal.serializer.types;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
 /**
@@ -29,6 +31,12 @@ class SqlTimestampSerializer extends AbstractDateSerializer<Timestamp> {
 
     SqlTimestampSerializer(TypeSerializerBuilder serializerBuilder) {
         super(serializerBuilder);
+    }
+
+    @Override
+    protected TemporalAccessor toTemporalAccessor(Timestamp value) {
+        // convert SQL Timestamp into a LocalDateTime to unlock TemporalAccessor access
+        return LocalDateTime.ofInstant(value.toInstant(), UTC);
     }
 
     @Override

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -16,6 +16,7 @@ import java.io.StringReader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -163,7 +164,7 @@ public class SerializersTest {
         JsonbConfig config = new JsonbConfig().withDeserializers(new CrateDeserializer());
         Jsonb jsonb = JsonbBuilder.create(config);
 
-        Box box = createPojoWithDates();
+        Box box = createPojoWithDates(getExpectedDate());
 
         String expected = "{\"boxStr\":\"Box string\",\"crate\":{\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\",\"date\":\"14.05.2015 || 11:10:01\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"date\":\"2015-05-14T11:10:01\"},\"secondBoxStr\":\"Second box string\"}";
 
@@ -251,12 +252,18 @@ public class SerializersTest {
     }
 
     @Test
+    public void testSqlTimestampSerialization() {
+        Box box = createPojoWithTimestamp(new Timestamp(getExpectedDate().getTime()));
+        assertTrue(defaultJsonb.toJson(box).contains("\"timestamp\":\"05/14/2015 @ 11:10\""));
+    }
+
+    @Test
     public void testSerializationUsingConversion() {
         JsonbConfig config = new JsonbConfig().withSerializers(new CrateSerializerWithConversion());
         Jsonb jsonb = JsonbBuilder.create(config);
 
         String json = "{\"boxStr\":\"Box string\",\"crate\":{\"crateStr\":\"REPLACED crate str\",\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\",\"date\":\"14.05.2015 || 11:10:01\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"crateBigDec\":54321,\"date-converted\":\"2015-05-14T11:10:01Z[UTC]\"},\"secondBoxStr\":\"Second box string\"}";
-        assertEquals(json, jsonb.toJson(createPojoWithDates()));
+        assertEquals(json, jsonb.toJson(createPojoWithDates(getExpectedDate())));
     }
 
     @Test
@@ -567,8 +574,13 @@ public class SerializersTest {
         }
     }
 
-    private static Box createPojoWithDates() {
-        Date date = getExpectedDate();
+    private static Box createPojoWithTimestamp(Timestamp timestamp) {
+        Box box = createPojo();
+        box.crate.timestamp = timestamp;
+        return box;
+    }
+
+    private static Box createPojoWithDates(Date date) {
         Box box = createPojo();
         box.crate.date = date;
         box.crate.crateInner.date = date;
@@ -580,7 +592,6 @@ public class SerializersTest {
         box.boxStr = "Box string";
         box.crate = new Crate();
         box.secondBoxStr = "Second box string";
-
 
         box.crate.crateInner = createCrateInner("Single inner");
 

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -16,6 +16,7 @@ import jakarta.json.bind.annotation.JsonbDateFormat;
 import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.json.bind.annotation.JsonbTypeSerializer;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
@@ -35,6 +36,9 @@ public class Crate {
 
     @JsonbDateFormat("dd.MM.yyy ^ HH:mm:ss")
     public Date date;
+
+    @JsonbDateFormat("MM/dd/yyy @ HH:mm")
+    public Timestamp timestamp;
 
     public AnnotatedWithSerializerType annotatedType;
 


### PR DESCRIPTION
While working on an unrelated project, I found an issue in Yasson when trying to serialize a POJO with a SQL Timestamp field with a custom date-time formatter enabled in Yasson configuration. The default formatters works just fine, but any explicitly specified formatter produces an NPE in ``SqlTimestampSerializer::formatWithFormatter`` method as it calls ``AbstractDateSerializer::toTemporalAccessor`` method which simply casts its argument to a ``TemporalAccessor``. This does not work with legacy java.sql.Timestamp object, however, as Timestamp does not implement a TemporalAccessor read-only interface.

Here is a small patch to the ``SqlTimestampSerializer`` class to convert a Timestamp into a ``LocalDateTime`` (Java 8 Date API) as both hold the same moment-in-time value, UTC time zone, so no information loss occurs. Resulting temporal field cannot be still serialized to JSON with a custom date-time format that includes unsupported elements such as time zone, for example, as neither SQL ``Timestamp`` nor ``LocaDateTime`` contain any time zone information. This is expected and is by design (of a rather messy ``java.sql.Timestamp`` class).