### PR TITLE
Fixed #589 (by adding skipObject() and skipArray() methods)

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/deserializer/ObjectDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/deserializer/ObjectDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
+++ b/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
@@ -121,6 +121,26 @@ public class JsonStructureToParserAdapter implements JsonParser {
     }
 
     @Override
+    public void skipArray() {
+        if (!iterators.isEmpty()) {
+            JsonStructureIterator current = iterators.peek();
+            if (current instanceof JsonArrayIterator) {
+                iterators.pop();
+            }
+        }
+    }
+
+    @Override
+    public void skipObject() {
+        if (!iterators.isEmpty()) {
+            JsonStructureIterator current = iterators.peek();
+            if (current instanceof JsonObjectIterator) {
+                iterators.pop();
+            }
+        }
+    }
+
+    @Override
     public void close() {
         //noop
     }

--- a/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
+++ b/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
@@ -16,9 +16,6 @@ import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import org.eclipse.yasson.internal.properties.MessageKeys;
-import org.eclipse.yasson.internal.properties.Messages;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
@@ -27,6 +24,9 @@ import jakarta.json.JsonValue;
 import jakarta.json.bind.JsonbException;
 import jakarta.json.stream.JsonLocation;
 import jakarta.json.stream.JsonParser;
+
+import org.eclipse.yasson.internal.properties.MessageKeys;
+import org.eclipse.yasson.internal.properties.Messages;
 
 /**
  * Adapter for {@link JsonParser}, that reads a {@link JsonStructure} content tree instead of JSON text.

--- a/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
+++ b/src/main/java/org/eclipse/yasson/internal/jsonstructure/JsonStructureToParserAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/model/JsonbAnnotatedElement.java
+++ b/src/main/java/org/eclipse/yasson/internal/model/JsonbAnnotatedElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -100,7 +100,7 @@ public class JsonbAnnotatedElement<T extends AnnotatedElement> {
 //        }
 //        annotations.put(annotation.annotationType(), new AnnotationWrapper(annotation, inherited));
         annotations.computeIfAbsent(annotation.annotationType(), aClass -> new LinkedList<>())
-                        .add(new AnnotationWrapper(annotation, inherited, definedType));
+                        .add(new AnnotationWrapper<Annotation>(annotation, inherited, definedType));
     }
 
     public void putAnnotationWrapper(AnnotationWrapper<?> annotationWrapper) {

--- a/src/test/java/org/eclipse/yasson/customization/polymorphism/NestedPolymorphismTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/polymorphism/NestedPolymorphismTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/customization/polymorphism/NestedPolymorphismTest.java
+++ b/src/test/java/org/eclipse/yasson/customization/polymorphism/NestedPolymorphismTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.yasson.customization.polymorphism;
+
+import jakarta.json.bind.annotation.JsonbSubtype;
+import jakarta.json.bind.annotation.JsonbTypeInfo;
+
+import org.eclipse.yasson.Jsonbs;
+import org.junit.jupiter.api.Test;
+
+import static org.eclipse.yasson.Jsonbs.defaultJsonb;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for verification of proper polymorphism handling based on annotation.
+ */
+public class NestedPolymorphismTest {
+
+    /**
+     * 1st test for: https://github.com/eclipse-ee4j/yasson/issues/589
+     * <p>(deserialization of nested polymorphic and unmapped properties)
+     */
+    @Test
+    public void testNestedUnmappedProperty() {
+        String json = "{\"inner\":{\"id\":123,\"@type\":\"derivationA\","
+                + "\"unmapped\":{\"x\":9,\"y\":[9,8,7]},\"name\":\"abc\"}}";
+        Outer obj = assertDoesNotThrow(() -> defaultJsonb.fromJson(json, Outer.class));
+        assertEquals(123L, obj.inner.id);
+        assertEquals("abc", obj.inner.name);
+    }
+
+    // a base class
+    @JsonbTypeInfo(key = "@type", value =
+            @JsonbSubtype(type = InnerBase.class, alias = "derivationA"))
+    public static class InnerBase {
+        public Long id;
+        public String name;
+    }
+
+    // derivation of the base class
+    public class Derivation extends InnerBase {}
+
+    // an arbitrary 'outer' root element
+    public static class Outer {
+        public InnerBase inner;
+    }
+
+    /**
+     * 2nd test for: https://github.com/eclipse-ee4j/yasson/issues/589
+     * <p>(deserialization of multiple nested polymorphic properties)
+     */
+    @Test
+    public void testNestedDeserialization() {
+        String json = "{\"@type\":\"Pets\",\"pet1\":{\"@type\":\"Cat\",\"name\":\"kitty\"}"
+                + ",\"pet2\":{\"@type\":\"Dog\",\"name\":\"puppy\"}}";
+        final Animals animals = Jsonbs.defaultJsonb.fromJson(json, Animals.class);
+        assertThat(animals, instanceOf(Pets.class));
+        assertNotNull(((Pets) animals).pet1, "Empty 'pet1' property");
+        assertEquals("kitty", ((Cat) ((Pets) animals).pet1).name, "First pet has invalid name");
+        assertNotNull(((Pets) animals).pet2, "Empty 'pet2' property");
+        assertThat("Invalid pet nr 2", ((Pets) animals).pet2, instanceOf(Dog.class));
+    }
+    
+    @JsonbTypeInfo(key = "@type", value = {
+            @JsonbSubtype(alias = "Dog", type = Dog.class),
+            @JsonbSubtype(alias = "Cat", type = Cat.class)
+    })
+    public interface Pet {
+        public String getType();
+    }
+
+    public static class Dog implements Pet {
+
+        public String name;
+
+        @Override
+        public String getType() {
+            return "Dog";
+        }
+    }
+
+    public static class Cat implements Pet {
+
+        public String name;
+
+        @Override
+        public String getType() {
+            return "Cat";
+        }
+    }
+
+    @JsonbTypeInfo(key = "@type", value = {
+            @JsonbSubtype(alias = "Pets", type = Pets.class),
+            @JsonbSubtype(alias = "Fishes", type = Fishes.class)
+        })
+    public interface Animals {
+
+    }
+
+    public static class Pets implements Animals {
+        public Pet pet1;
+        public Pet pet2;
+    }
+
+    public static class Fishes implements Animals {
+
+    }
+
+}

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -14,25 +14,17 @@ package org.eclipse.yasson.internal.serializer;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
-
-import org.eclipse.yasson.adapters.AdaptersTest.StringAdapter;
-
 import static org.eclipse.yasson.Jsonbs.*;
 
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbConfig;
 import jakarta.json.bind.JsonbException;
-import jakarta.json.bind.annotation.JsonbTypeInfo;
-import jakarta.json.bind.annotation.JsonbSubtype;
 
 public class ObjectDeserializerTest {
 
     @Test
     public void testGetInstanceExceptionShouldContainClassNameOnMissingConstructor() {
-    	assertThrows(JsonbException.class, 
-    				() -> defaultJsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class),
-    				DummyDeserializationClass.class::getName);
+        assertThrows(JsonbException.class, 
+                () -> defaultJsonb.fromJson("{\"key\":\"value\"}", DummyDeserializationClass.class),
+                DummyDeserializationClass.class::getName);
     }
 
     public static class DummyDeserializationClass {
@@ -49,34 +41,5 @@ public class ObjectDeserializerTest {
         public void setKey(String key) {
             this.key = key;
         }
-    }
-
-
-    
-    /**
-     * Test for: https://github.com/eclipse-ee4j/yasson/issues/589
-     */
-    @Test
-    public void testNestedUnmappedProperty() {
-        String json = "{\"inner\":{\"id\":123,\"_type\":\"derivationA\","
-                + "\"unmapped\":{\"x\":9,\"y\":[9,8,7]},\"name\":\"abc\"}}";
-        Outer obj = assertDoesNotThrow(() -> defaultJsonb.fromJson(json, Outer.class));
-        assertEquals(123L, obj.inner.id);
-        assertEquals("abc", obj.inner.name);
-    }
-
-    // a base class
-    @JsonbTypeInfo(key = "_type", value = @JsonbSubtype(type = InnerBase.class, alias = "derivationA"))
-    public static class InnerBase {
-        public Long id;
-        public String name;
-    }
-
-    // derivation of the base class
-    public class Derivation extends InnerBase {}
-
-    // an arbitrary 'outer' root element
-    public static class Outer {
-        public InnerBase inner;
     }
 }

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
+++ b/src/test/java/org/eclipse/yasson/internal/serializer/ObjectDeserializerTest.java
@@ -14,9 +14,17 @@ package org.eclipse.yasson.internal.serializer;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.yasson.adapters.AdaptersTest.StringAdapter;
+
 import static org.eclipse.yasson.Jsonbs.*;
 
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
 import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.annotation.JsonbTypeInfo;
+import jakarta.json.bind.annotation.JsonbSubtype;
 
 public class ObjectDeserializerTest {
 
@@ -41,5 +49,34 @@ public class ObjectDeserializerTest {
         public void setKey(String key) {
             this.key = key;
         }
+    }
+
+
+    
+    /**
+     * Test for: https://github.com/eclipse-ee4j/yasson/issues/589
+     */
+    @Test
+    public void testNestedUnmappedProperty() {
+        String json = "{\"inner\":{\"id\":123,\"_type\":\"derivationA\","
+                + "\"unmapped\":{\"x\":9,\"y\":[9,8,7]},\"name\":\"abc\"}}";
+        Outer obj = assertDoesNotThrow(() -> defaultJsonb.fromJson(json, Outer.class));
+        assertEquals(123L, obj.inner.id);
+        assertEquals("abc", obj.inner.name);
+    }
+
+    // a base class
+    @JsonbTypeInfo(key = "_type", value = @JsonbSubtype(type = InnerBase.class, alias = "derivationA"))
+    public static class InnerBase {
+        public Long id;
+        public String name;
+    }
+
+    // derivation of the base class
+    public class Derivation extends InnerBase {}
+
+    // an arbitrary 'outer' root element
+    public static class Outer {
+        public InnerBase inner;
     }
 }


### PR DESCRIPTION
A fix for a straightforward issue #589 discovered by @DXTR66. The fix is about letting ``JsonStructureToParserAdapter `` parser adapter implement ``skipObject()`` and ``skipArray()`` methods, so both can be used by the caller without a fear of raising an unsupported-method-exception.