### PR TITLE
Eliminate Stream in #wrapInCommonSet

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/SerializationModelCreator.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/SerializationModelCreator.java
@@ -24,7 +24,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 import jakarta.json.bind.JsonbException;
 
@@ -73,11 +72,8 @@ public class SerializationModelCreator {
     public static ModelSerializer wrapInCommonSet(ModelSerializer modelSerializer,
                                                   Customization customization,
                                                   JsonbContext jsonbContext) {
-        return Stream.of(modelSerializer)
-                .map(KeyWriter::new)
-                .map(serializer -> new NullSerializer(serializer, customization, jsonbContext))
-                .findFirst()
-                .get();
+        KeyWriter serializer = new KeyWriter(modelSerializer);
+        return new NullSerializer(serializer, customization, jsonbContext);
     }
 
     /**


### PR DESCRIPTION
Elminate Stream creation in SerializationModelCreator#wrapInCommonSet as it was showing in during profiling.

`SerializationModelCreator#wrapInCommonSet` uses a single element stream to create a `KeyWriter` and `NullSerializer`. C2 is not able to optimize this away and the internal allocations of the stream API show up during profiling.

![wrapInCommonSet](https://github.com/eclipse-ee4j/yasson/assets/471021/20f913fd-77dd-4d07-b376-fbdd07b3f5b5)
