### PR TITLE
[#617]User defined deserializer always should be used before standard…

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/deserializer/DeserializationModelCreator.java
+++ b/src/main/java/org/eclipse/yasson/internal/deserializer/DeserializationModelCreator.java
@@ -152,6 +152,17 @@ public class DeserializationModelCreator {
             models.put(cachedItem, deserializer);
             return deserializer;
         }
+
+        ClassCustomization classCustomization = classModel.getClassCustomization();
+        Optional<DeserializerBinding<?>> deserializerBinding = userDeserializer(type,
+                (ComponentBoundCustomization) propertyCustomization);
+        if (deserializerBinding.isPresent()) {
+            UserDefinedDeserializer user = new UserDefinedDeserializer(deserializerBinding.get().getJsonbDeserializer(),
+                    JustReturn.instance(), type, classCustomization);
+            models.put(cachedItem, user);
+            return user;
+        }
+
         Optional<AdapterBinding> adapterBinding = adapterBinding(type, (ComponentBoundCustomization) propertyCustomization);
         if (adapterBinding.isPresent()) {
             AdapterBinding adapter = adapterBinding.get();
@@ -201,14 +212,6 @@ public class DeserializationModelCreator {
                                                                    Class<?> rawType,
                                                                    CachedItem cachedItem) {
         ClassCustomization classCustomization = classModel.getClassCustomization();
-        Optional<DeserializerBinding<?>> deserializerBinding = userDeserializer(type,
-                                                                                (ComponentBoundCustomization) propertyCustomization);
-        if (deserializerBinding.isPresent()) {
-            UserDefinedDeserializer user = new UserDefinedDeserializer(deserializerBinding.get().getJsonbDeserializer(),
-                                                                       JustReturn.instance(), type, classCustomization);
-            models.put(cachedItem, user);
-            return user;
-        }
         JsonbCreator creator = classCustomization.getCreator();
         boolean hasCreator = creator != null;
         List<String> params = hasCreator ? creatorParamsList(creator) : Collections.emptyList();

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -51,6 +51,7 @@ import org.eclipse.yasson.serializers.model.AnnotatedWithSerializerType;
 import org.eclipse.yasson.serializers.model.Author;
 import org.eclipse.yasson.serializers.model.Box;
 import org.eclipse.yasson.serializers.model.BoxWithAnnotations;
+import org.eclipse.yasson.serializers.model.Colors;
 import org.eclipse.yasson.serializers.model.Containee;
 import org.eclipse.yasson.serializers.model.Container;
 import org.eclipse.yasson.serializers.model.Crate;
@@ -810,6 +811,17 @@ public class SerializersTest {
 
         assertEquals(expected, jsonb.fromJson(expectedJson, Container.class));
 
+    }
+
+    @Test
+    void testCustomSerializersAndDeserializersInEnum(){
+        Jsonb jsonb = JsonbBuilder.create();
+
+        Colors expected = Colors.GREEN;
+
+        String expectedJson = jsonb.toJson(expected);
+
+        assertEquals(expected, jsonb.fromJson(expectedJson, Colors.class));
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/serializers/model/Colors.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Colors.java
@@ -1,0 +1,15 @@
+package org.eclipse.yasson.serializers.model;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTypeDeserializer;
+import jakarta.json.bind.annotation.JsonbTypeSerializer;
+
+@JsonbTypeSerializer(ColorsSerializer.class)
+@JsonbTypeDeserializer(ColorsDeserializer.class)
+public enum Colors {
+	@JsonbProperty("Red")
+	RED,
+	@JsonbProperty("Green")
+	GREEN
+}
+

--- a/src/test/java/org/eclipse/yasson/serializers/model/ColorsDeserializer.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/ColorsDeserializer.java
@@ -1,0 +1,8 @@
+package org.eclipse.yasson.serializers.model;
+
+public class ColorsDeserializer extends EnumWithJsonbPropertyDeserializer<Colors> {
+
+	public ColorsDeserializer() {
+		super();
+	}
+}

--- a/src/test/java/org/eclipse/yasson/serializers/model/ColorsSerializer.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/ColorsSerializer.java
@@ -1,0 +1,7 @@
+package org.eclipse.yasson.serializers.model;
+
+public class ColorsSerializer extends EnumWithJsonbPropertySerializer<Colors> {
+	public ColorsSerializer() {
+		super();
+	}
+}

--- a/src/test/java/org/eclipse/yasson/serializers/model/EnumWithJsonbPropertyDeserializer.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/EnumWithJsonbPropertyDeserializer.java
@@ -1,0 +1,57 @@
+package org.eclipse.yasson.serializers.model;
+
+import static java.util.Optional.ofNullable;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+public class EnumWithJsonbPropertyDeserializer<E extends Enum<E>> implements JsonbDeserializer<E> {
+
+	private final Map<String, E> jsonToJavaMapping;
+
+	public EnumWithJsonbPropertyDeserializer() {
+		super();
+
+		Class<E> enumType = getEnumType();
+		jsonToJavaMapping = new HashMap<>();
+
+		Stream.of(enumType.getEnumConstants()).forEach(constant -> {
+			final String asString;
+			try {
+				asString = ofNullable(
+						constant.getClass()
+								.getDeclaredField(constant.name())
+								.getAnnotation(JsonbProperty.class))
+						.map(JsonbProperty::value)
+						.orElseGet(constant::name);
+			} catch (final NoSuchFieldException e) {
+				throw new IllegalArgumentException(e);
+			}
+			jsonToJavaMapping.put(asString, constant);
+		});
+	}
+
+	private Class<E> getEnumType() {
+		return Class.class.cast(ParameterizedType.class.cast(
+						getClass().getGenericSuperclass())
+				.getActualTypeArguments()[0]);
+	}
+
+	@Override
+	public E deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+		String key = parser.getString();
+
+		assert key != null;
+
+		return ofNullable(jsonToJavaMapping.get(key))
+				.orElseThrow(() -> new IllegalArgumentException("Unknown enum value: '" + key + "'"));
+	}
+}

--- a/src/test/java/org/eclipse/yasson/serializers/model/EnumWithJsonbPropertySerializer.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/EnumWithJsonbPropertySerializer.java
@@ -1,0 +1,48 @@
+package org.eclipse.yasson.serializers.model;
+
+import static java.util.Optional.ofNullable;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.EnumMap;
+import java.util.stream.Stream;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.serializer.JsonbSerializer;
+import jakarta.json.bind.serializer.SerializationContext;
+import jakarta.json.stream.JsonGenerator;
+
+public class EnumWithJsonbPropertySerializer<E extends Enum<E>> implements JsonbSerializer<E> {
+	private final EnumMap<E, String> javaToJsonMapping;
+
+	public EnumWithJsonbPropertySerializer() {
+		super();
+
+		Class<E> enumType = getEnumType();
+		javaToJsonMapping = new EnumMap<>(enumType);
+
+		Stream.of(enumType.getEnumConstants()).forEach(constant -> {
+			final String asString;
+			try {
+				asString = ofNullable(
+						constant.getClass()
+								.getDeclaredField(constant.name())
+								.getAnnotation(JsonbProperty.class))
+						.map(JsonbProperty::value)
+						.orElseGet(constant::name);
+			} catch (final NoSuchFieldException e) {
+				throw new IllegalArgumentException(e);
+			}
+			javaToJsonMapping.put(constant, asString);
+		});
+	}
+
+	private Class<E> getEnumType() {
+		return Class.class.cast(ParameterizedType.class.cast(
+						getClass().getGenericSuperclass())
+				.getActualTypeArguments()[0]);
+	}
+
+	@Override public void serialize(E obj, JsonGenerator generator, SerializationContext ctx) {
+		generator.write(javaToJsonMapping.get(obj));
+	}
+}


### PR DESCRIPTION
… ones.

Created a correction for #617. I little bit of explanations: the culprit is in the TypeDeserializers#assignableCases. Here, the EnumDeserializer will be created for any Enum type. But here we are missing some objects needed to create a user deserializer. So we have to create it earlier in the call stack, directly in the DeserializationModelCreator#deserializerChainInternal, before the call of DeserializationModelCreator#typeDeserializer. 

This way it would be effective for all classes, not just the enums.

On the other hand, I looked on the SerializationModelCreator. Here one first looks in the cache, then for user defined serializer, then for user defined adapter. And only after that the standard serializer would be created. So now both DeserializationModelCreator and SerializationModelCreator will share the same logic on creation of custom / standard elements.

And I forget an `Signed-off-by: Anton Pinsky <anton.pinsky@ionos.com>` - could I change it?