### PR TITLE
fix: check on possible null pointer dereference

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/ReflectionUtils.java
+++ b/src/main/java/org/eclipse/yasson/internal/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/deserializer/DeserializationModelCreator.java
+++ b/src/main/java/org/eclipse/yasson/internal/deserializer/DeserializationModelCreator.java
@@ -224,17 +224,20 @@ public class DeserializationModelCreator {
         }
         for (String s : params) {
             CreatorModel creatorModel = creator.findByName(s);
-            ModelDeserializer<JsonParser> modelDeserializer = typeProcessor(chain,
-                                                                            creatorModel.getType(),
-                                                                            creatorModel.getCustomization(),
-                                                                            JustReturn.instance());
-            String parameterName = renamer.apply(creatorModel.getName());
-            processors.put(parameterName, modelDeserializer);
-            if (creatorModel.getCustomization().isRequired()) {
-                defaultCreatorValues.put(parameterName, new RequiredCreatorParameter(parameterName));
-            } else {
-                Class<?> rawParamType = ReflectionUtils.getRawType(creatorModel.getType());
-                defaultCreatorValues.put(parameterName, DEFAULT_CREATOR_VALUES.getOrDefault(rawParamType, NULL_PROVIDER));
+            if (creatorModel != null) {
+                ModelDeserializer<JsonParser> modelDeserializer = typeProcessor(chain,
+                        creatorModel.getType(),
+                        creatorModel.getCustomization(),
+                        JustReturn.instance());
+                String parameterName = renamer.apply(creatorModel.getName());
+                processors.put(parameterName, modelDeserializer);
+                if (creatorModel.getCustomization().isRequired()) {
+                    defaultCreatorValues.put(parameterName, new RequiredCreatorParameter(parameterName));
+                } else {
+                    Class<?> rawParamType = ReflectionUtils.getRawType(creatorModel.getType());
+                    defaultCreatorValues.put(parameterName,
+                            DEFAULT_CREATOR_VALUES.getOrDefault(rawParamType, NULL_PROVIDER));
+                }
             }
         }
         ModelDeserializer<JsonParser> instanceCreator;

--- a/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/generics/GenericsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/defaultmapping/generics/model/LowerBoundTypeVariableWithCollectionAttributeClass.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/generics/model/LowerBoundTypeVariableWithCollectionAttributeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
#### Motivation

In file: DeserializationModelCreator.java, class: DeserializationModelCreator, there is a method createObjectDeserializer that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program.  A developer should introduce null checks in the appropriate path or initialize the object explicitly.

#### Path of Possible Null Pointer Dereference

In file DeserializationModelCreator.java the following line of code (line 226)

```java
CreatorModel creatorModel = creator.findByName(s);
```

invokes a method call of `JsonbCreator` class `findByName`

```java
public CreatorModel findByName(String paramName) {
        for (CreatorModel param : params) {
            if (param.getName().equals(paramName)) {
                return param;
            }
        }
        return null;
    }
```

which can return null which was not properly checked before referencing `CreatorModel` from DeserializationModelCreator.java (line 227)

#### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.