### PR TITLE
Upgrade parsson from 1.1.0 to 1.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jakarta.json.version>2.1.0</jakarta.json.version>
-        <parson.version>2.1.0</parson.version>
+        <jakarta.json.version>2.1.3</jakarta.json.version>
+        <parsson.version>1.1.5</parsson.version>
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <netbeans.hint.jdkPlatform>JDK_9</netbeans.hint.jdkPlatform>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
-            <version>1.1.0</version>
+            <version>${parsson.version}</version>
         </dependency>
         <!-- Test/Provided dependencies -->
         <dependency>


### PR DESCRIPTION
it avoids to have scanner reporting security issue related to https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEPARSSON-6044728

it requires to align jakarta.json-api version