### PR TITLE
Support for ISO_DATE to Date deserialization

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/deserializer/types/DateDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/deserializer/types/DateDeserializer.java
@@ -13,10 +13,14 @@
 package org.eclipse.yasson.internal.deserializer.types;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Locale;
+
+import static java.time.ZoneId.systemDefault;
 
 /**
  * Deserializer of the {@link Date} type.
@@ -36,7 +40,12 @@ class DateDeserializer extends AbstractDateDeserializer<Date> {
 
     @Override
     Date parseDefault(String jsonValue, Locale locale) {
-        return parseWithOrWithoutZone(jsonValue, DEFAULT_DATE_TIME_FORMATTER.withLocale(locale));
+        try {
+            return parseWithOrWithoutZone(jsonValue, DEFAULT_DATE_TIME_FORMATTER.withLocale(locale));
+        } catch (DateTimeParseException e3) {
+            LocalDate localDate = LocalDate.parse(jsonValue, DateTimeFormatter.ISO_DATE);
+            return Date.from(localDate.atStartOfDay(systemDefault()).toInstant());
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #487.

Deserializes plain ISO_DATE, e.g. "2024-08-21" to `java.util.Date` in the default system timezone. The reason is that the date is meant to be a date and not exact time. So the final Date instance has the same date in the local timezone as the date on the input.

Dealing with timezones is a bit confusing to me. If somebody thinks it's better to convert the date using UTC, let me know. However, I think the default timezone is a reasonable default. 