### PR TITLE
Do not close passed-in Writer (#604)

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/JsonBinding.java
+++ b/src/main/java/org/eclipse/yasson/internal/JsonBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,6 +12,7 @@
 
 package org.eclipse.yasson.internal;
 
+import java.io.FilterWriter;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
@@ -145,7 +146,7 @@ public class JsonBinding implements YassonJsonb {
     @Override
     public void toJson(Object object, Writer writer) throws JsonbException {
         final SerializationContextImpl marshaller = new SerializationContextImpl(jsonbContext);
-        try (JsonGenerator generator = writerGenerator(writer)) {
+        try (JsonGenerator generator = writerGenerator(new CloseSuppressingWriter(writer))) {
             marshaller.marshallWithoutClose(object, generator);
         }
     }
@@ -153,7 +154,7 @@ public class JsonBinding implements YassonJsonb {
     @Override
     public void toJson(Object object, Type type, Writer writer) throws JsonbException {
         final SerializationContextImpl marshaller = new SerializationContextImpl(jsonbContext, type);
-        try (JsonGenerator generator = writerGenerator(writer)) {
+        try (JsonGenerator generator = writerGenerator(new CloseSuppressingWriter(writer))) {
             marshaller.marshallWithoutClose(object, generator);
         }
     }
@@ -232,6 +233,19 @@ public class JsonBinding implements YassonJsonb {
     @Override
     public void close() throws Exception {
         jsonbContext.getComponentInstanceCreator().close();
+    }
+
+    private static class CloseSuppressingWriter extends FilterWriter {
+
+        protected CloseSuppressingWriter(final Writer in) {
+            super(in);
+        }
+
+        @Override
+        public void close() {
+            // do not close
+        }
+
     }
 
 }


### PR DESCRIPTION
Do not close the `Writer` resources that has been supplied to the `JsonBinding` methods by the caller. Let the latter manage the lifecycle of the output writer. This prevents `java.io.IOException: Stream closed` errors with Spring Native and Spring Boot when generating a JSON response from an HTTP method, for example, as Spring assumes the JSON-B implementation serializes the passed in POJO into JSON, writes it to a supplied `Writer` but does not close it yet. Flushing the output is perfectly fine and is acceptable, of course.

See #604 for details of the regression introduced in Yasson 3.0.3 and #389 for the description of the original bug.