### PR TITLE
[655] java.sql.Time throws java.lang.UnsupportedOperationException when serialized

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlDateSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlDateSerializer.java
@@ -28,7 +28,7 @@ class SqlDateSerializer extends DateSerializer<Date> {
 
     @Override
     protected Instant toInstant(Date value) {
-        if (value instanceof java.sql.Date) {
+        if (value instanceof java.sql.Date || value instanceof java.sql.Time) {
             // java.sql.Date doesn't have a time component, so do our best if TIME_IN_MILLIS is requested
             // In the future (at a breaking change boundary) we should probably reject this code path
             return Instant.ofEpochMilli(value.getTime());

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -69,6 +69,7 @@ import org.eclipse.yasson.serializers.model.RecursiveDeserializer;
 import org.eclipse.yasson.serializers.model.RecursiveSerializer;
 import org.eclipse.yasson.serializers.model.SimpleAnnotatedSerializedArrayContainer;
 import org.eclipse.yasson.serializers.model.SimpleContainer;
+import org.eclipse.yasson.serializers.model.SqlTimeBean;
 import org.eclipse.yasson.serializers.model.StringWrapper;
 import org.eclipse.yasson.serializers.model.SupertypeSerializerPojo;
 import org.junit.jupiter.api.Test;
@@ -199,6 +200,19 @@ public class SerializersTest {
         assertNull(result.crate.crateStr);
         assertEquals(pojo.crate.crateInner.crateInnerStr, result.crate.crateInner.crateInnerStr);
         assertEquals(pojo.crate.crateInner.crateInnerBigDec, result.crate.crateInner.crateInnerBigDec);
+    }
+
+    @Test
+    public void testSerializerSerializationOfSqlTime() {
+        JsonbConfig config = new JsonbConfig().withSerializers(new CrateSerializer());
+        Jsonb jsonb = JsonbBuilder.create(config);
+        String expected = "{\"time\":\"1970-01-01T11:00:00Z[UTC]\"}";
+
+        SqlTimeBean value = new SqlTimeBean();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        value.setTime(java.sql.Time.valueOf("11:00:00"));
+
+        assertEquals(expected, jsonb.toJson(value));
     }
 
     @Test

--- a/src/test/java/org/eclipse/yasson/serializers/model/SqlTimeBean.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/SqlTimeBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.yasson.serializers.model;
+
+import java.sql.Time;
+
+public class SqlTimeBean {
+
+    private java.sql.Time time;
+
+    public Time getTime() {
+        return time;
+    }
+
+    public void setTime(Time time) {
+        this.time = time;
+    }
+}


### PR DESCRIPTION
https://github.com/eclipse-ee4j/yasson/issues/655