### PR TITLE
[676] UnsupportedTemporalTypeException when serializing java.sql.Date with formatter containing time component fields

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlDateSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlDateSerializer.java
@@ -14,13 +14,17 @@ package org.eclipse.yasson.internal.serializer.types;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Date;
 import java.util.Locale;
+import java.util.logging.Logger;
 
 /**
  * Common serializer for {@link Date} and {@link java.sql.Date} types.
  */
 class SqlDateSerializer extends DateSerializer<Date> {
+
+    private static final Logger LOGGER = Logger.getLogger(SqlDateSerializer.class.getName());
 
     SqlDateSerializer(TypeSerializerBuilder serializerBuilder) {
         super(serializerBuilder);
@@ -49,9 +53,12 @@ class SqlDateSerializer extends DateSerializer<Date> {
     @Override
     protected String formatWithFormatter(Date value, DateTimeFormatter formatter) {
         if (value instanceof java.sql.Date) {
-            return ((java.sql.Date) value).toLocalDate().format(formatter);
-        } else {
-            return super.formatWithFormatter(value, formatter);
+            try {
+                return ((java.sql.Date) value).toLocalDate().format(formatter);
+            } catch (UnsupportedTemporalTypeException exception) {
+                LOGGER.warning(exception.getMessage());
+            }
         }
+        return super.formatWithFormatter(value, formatter);
     }
 }

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -69,6 +69,7 @@ import org.eclipse.yasson.serializers.model.RecursiveDeserializer;
 import org.eclipse.yasson.serializers.model.RecursiveSerializer;
 import org.eclipse.yasson.serializers.model.SimpleAnnotatedSerializedArrayContainer;
 import org.eclipse.yasson.serializers.model.SimpleContainer;
+import org.eclipse.yasson.serializers.model.SqlDateBean;
 import org.eclipse.yasson.serializers.model.StringWrapper;
 import org.eclipse.yasson.serializers.model.SupertypeSerializerPojo;
 import org.junit.jupiter.api.Test;
@@ -199,6 +200,19 @@ public class SerializersTest {
         assertNull(result.crate.crateStr);
         assertEquals(pojo.crate.crateInner.crateInnerStr, result.crate.crateInner.crateInnerStr);
         assertEquals(pojo.crate.crateInner.crateInnerBigDec, result.crate.crateInner.crateInnerBigDec);
+    }
+
+    @Test
+    public void testSerializationOfSqlDateWithFormatter() {
+        JsonbConfig config = new JsonbConfig().withSerializers(new CrateSerializer());
+        Jsonb jsonb = JsonbBuilder.create(config);
+        String expected = "{\"date\":\"2019-01-26T00:00:00.000+0000\"}";
+
+        SqlDateBean value = new SqlDateBean();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        value.setDate(java.sql.Date.valueOf("2019-01-26"));
+
+        assertEquals(expected, jsonb.toJson(value));
     }
 
     @Test

--- a/src/test/java/org/eclipse/yasson/serializers/model/SqlDateBean.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/SqlDateBean.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.yasson.serializers.model;
+
+import jakarta.json.bind.annotation.JsonbDateFormat;
+
+import java.sql.Date;
+
+public class SqlDateBean {
+
+    @JsonbDateFormat(value = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    private java.sql.Date date;
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+}


### PR DESCRIPTION
https://github.com/eclipse-ee4j/yasson/issues/676