### PR TITLE
recreate: use a generic parameter in a record

### DIFF
--- a/src/test/java/org/eclipse/yasson/records/CarWithGenerics.java
+++ b/src/test/java/org/eclipse/yasson/records/CarWithGenerics.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.yasson.records;
+
+public record CarWithGenerics<T> (String type, T color)  {
+}

--- a/src/test/java/org/eclipse/yasson/records/Color.java
+++ b/src/test/java/org/eclipse/yasson/records/Color.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 IBM and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.yasson.records;
+    
+public record Color(String name, String code) {
+}

--- a/src/test/java/org/eclipse/yasson/records/RecordTest.java
+++ b/src/test/java/org/eclipse/yasson/records/RecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.yasson.records;
 import jakarta.json.bind.JsonbException;
 
 import org.eclipse.yasson.Jsonbs;
+import org.eclipse.yasson.TestTypeToken;
 import org.eclipse.yasson.internal.properties.MessageKeys;
 import org.eclipse.yasson.internal.properties.Messages;
 import org.junit.jupiter.api.Test;
@@ -106,4 +107,16 @@ public class RecordTest {
         assertThrows(JsonbException.class, () -> Jsonbs.defaultJsonb.fromJson(expected, CarWithDefaultConstructor.class));
     }
 
+    @Test
+    public void testRecordWithGenerics() {
+        CarWithGenerics<Color> car = new CarWithGenerics<>("skoda", new Color("green", "#00FF00"));
+        String expected = "{\"color\":{\"code\":\"#00FF00\",\"name\":\"green\"},\"type\":\"skoda\"}";
+
+        String json = Jsonbs.defaultJsonb.toJson(car);
+        assertThat(json, is(expected));
+        
+        CarWithGenerics<Color> deserialized = Jsonbs.defaultJsonb
+                .fromJson(expected, new TestTypeToken<CarWithGenerics<Color>>() {}.getType());
+        assertThat(deserialized, is(car));  
+    }
 }


### PR DESCRIPTION
Fixes #681 

Attempt to recreate user reported bug. 
Found that yasson correctly serialized and deserialized the generic type defined in the record.
Asking original user to verify