### PR TITLE
security: update github actions and keep updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+# TODO - add maven dependabot if community agrees it's useful

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout for build
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Set up compile JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with: #Compile java needs to be the highest to ensure proper compilation of the multi-release jar
           distribution: 'temurin'
           java-version: 17


### PR DESCRIPTION
- Use SHA versions of Github Action dependencies to avoid supply chain attacks.
- Add Dependabot to workflow to keep these dependencies up to date. 