### PR TITLE
Fix date deserialization with date-only formats

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/deserializer/types/DateDeserializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/deserializer/types/DateDeserializer.java
@@ -13,8 +13,10 @@
 package org.eclipse.yasson.internal.deserializer.types;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.Locale;
 
@@ -45,13 +47,12 @@ class DateDeserializer extends AbstractDateDeserializer<Date> {
     }
 
     private static Date parseWithOrWithoutZone(String jsonValue, DateTimeFormatter formatter) {
-        ZonedDateTime parsed;
-        if (formatter.getZone() == null) {
-            parsed = ZonedDateTime.parse(jsonValue, formatter.withZone(UTC));
-        } else {
-            parsed = ZonedDateTime.parse(jsonValue, formatter);
+        DateTimeFormatter formatterWithZone = formatter.getZone() == null ? formatter.withZone(UTC) : formatter;
+        TemporalAccessor parsed = formatterWithZone.parseBest(jsonValue, ZonedDateTime::from, LocalDate::from);
+        if (parsed instanceof ZonedDateTime) {
+            return Date.from(((ZonedDateTime) parsed).toInstant());
         }
-        return Date.from(parsed.toInstant());
+        return Date.from(((LocalDate) parsed).atStartOfDay(UTC).toInstant());
     }
 
 }

--- a/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
+++ b/src/test/java/org/eclipse/yasson/defaultmapping/dates/DatesTest.java
@@ -104,6 +104,11 @@ public class DatesTest {
         public java.sql.Date sqlDate;
     }
 
+    public static class UtilDateWithDateFormat {
+        @JsonbDateFormat(value = "yyyy-MM-dd")
+        public java.util.Date utilDate;
+    }
+
     @Test
     public void testSqlTimestamp() {
         Timestamp expectedTimestamp = Timestamp.from(Instant.now());
@@ -189,6 +194,13 @@ public class DatesTest {
         } finally {
             TimeZone.setDefault(originalTZ);
         }
+    }
+
+    @Test
+    public void testUtilDateWithDateOnlyFormat() {
+        UtilDateWithDateFormat result = bindingJsonb.fromJson("{\"utilDate\":\"2026-02-25\"}", UtilDateWithDateFormat.class);
+        LocalDate expected = LocalDate.of(2026, 2, 25);
+        assertEquals(expected, result.utilDate.toInstant().atZone(ZoneOffset.UTC).toLocalDate());
     }
 
     @Test


### PR DESCRIPTION
Fixes #695. The deserializer was forcing ZonedDateTime.parse() for everything, which fails with date-only formats like 'yyyy-MM-dd'. Now uses parseBest() to handle both ZonedDateTime and LocalDate correctly. Added a test to prevent regression.