### PR TITLE
build: allow pipeline to run against staged TCK

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2026 Eclipse Foundation and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# This workflow performs performance testing using JMH.
+# It is intended to be run on a schedule (e.g. weekly) to track performance over time, but can also be triggered manually when needed.
+# Persist results to github pages for continuous line graphs and regression alerts.
+
+name: Performance
+
+on:
+    schedule:
+        # Runs every Tuesday at 4:13 AM UTC (avoid peak hours for better performance results)
+        - cron: '13 4 * * 2' 
+    workflow_dispatch:
+    
+jobs:
+    performance:
+        name: Run JMH performance tests
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout for performance
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                fetch-depth: 0
+            - name: Set up compile JDK
+              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+              with: #Compile java needs to be the highest to ensure proper compilation of the multi-release jar
+                distribution: 'temurin'
+                java-version: 17
+                cache: 'maven'
+            - name: Compile Yasson
+              run: |
+                mvn -U -C clean install -DskipTests
+            - name: Run JMH performance tests
+              run: |
+                cd yasson-jmh
+                mvn -U -B clean package
+                java -jar target/yasson-jmh.jar -rf json -rff jmh-result.json
+            - name: Persist JMH results
+              uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+              with:
+                name: Java JMH Benchmark
+                tool: 'jmh'
+                output-file-path: jmh-result.json
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+            
+                # Enable deployment to GitHub Pages for continuous line graphs
+                auto-push: true
+                comment-on-alert: true       # Creates a comment if performance degrades
+                fail-on-alert: true          # Fails the workflow run on regression
+                alert-threshold: '200%'      # Triggers an alert if execution time doubles
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2026 Eclipse Foundation and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# This workflow is used to verify this project against staged versions of the API and TCK. 
+# It is not intended to be used for regular CI builds, but rather as a manual workflow that can be triggered when needed.
+
+name: Verify
+
+on:
+    workflow_dispatch:
+        inputs:
+            jsonb_version:
+                description: 'The version of the TCK to verify against (e.g. 3.1.0-M1)'
+                required: true
+
+jobs:
+    verify:
+        name: Verify against staged API or TCK
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout for verify
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                fetch-depth: 0
+            - name: Set up compile JDK
+              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+              with: #Compile java needs to be the highest to ensure proper compilation of the multi-release jar
+                distribution: 'temurin'
+                java-version: 17
+                cache: 'maven'
+            - name: Compile Yasson
+              run: |
+                mvn -U -C clean install \
+                    -Pstaged \
+                    -Djakarta.json.bind.version=${{ github.event.inputs.jsonb_version }} \
+                    -DskipTests
+            - name: Run TCK
+              run: |
+                cd yasson-tck
+                mvn -U -B test \
+                    -Pstaged \
+                    -Djakarta.json.bind.version=${{ github.event.inputs.jsonb_version }} \
+                    -Djsonb.tck.version=${{ github.event.inputs.jsonb_version }} \
+                    -DargLine="-Djava.locale.providers=COMPAT"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .project
 .idea/
 .settings/
-/.DS_Store
+.DS_Store
 bin/
 .envrc
 .vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
     </parent>
 
     <groupId>org.eclipse</groupId>
@@ -34,21 +34,30 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
+        
         <nexus.staging.repository>yasson-maven2-staging</nexus.staging.repository>
 
         <!--Dependencies-->
         <hamcrest.version>2.2</hamcrest.version>
+        
+        <!-- Jakarta API -->
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.el-api.version>6.0.0</jakarta.el-api.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
         <jakarta.json.bind.version>3.0.1</jakarta.json.bind.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
-        <jakarta.parson.version>1.1.7</jakarta.parson.version>
-        <junit-jupiter.version>5.10.2</junit-jupiter.version>
-        <weld-se-core.version>6.0.0.Beta1</weld-se-core.version>
+
+        <!-- Jakarta Implementation -->
+        <jakarta.parson.version>1.1.9</jakarta.parson.version>
+
+        <!-- Test dependencies-->
+        <junit-jupiter.version>5.14.4</junit-jupiter.version> <!-- TODO update to Junit 6 when running on Java 17+ -->
+        <weld-se-core.version>6.0.4.Final</weld-se-core.version>
 
         <!--Plugins-->
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
@@ -365,9 +374,9 @@
                                 <goal>compile</goal>
                             </goals>
                             <configuration>
-                                <release>11</release>
-                                <source>11</source>
-                                <target>11</target>
+                                <release>${maven.compiler.release}</release>
+                                <source>${maven.compiler.release}</source>
+                                <target>${maven.compiler.release}</target>
                             </configuration>
                         </execution>
                         <execution>
@@ -434,7 +443,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
-                        <bottom><![CDATA[Copyright &#169; 2017, 2024 Oracle Corporation. All rights reserved.<br>]]></bottom>
+                        <bottom><![CDATA[Copyright &#169; 2017, 2026 Oracle Corporation. All rights reserved.<br>]]></bottom>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/yasson-jmh/pom.xml
+++ b/yasson-jmh/pom.xml
@@ -5,6 +5,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>2.0.4</version>
+    </parent>
+
     <groupId>org.eclipse.yasson</groupId>
     <artifactId>yasson-jmh</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -14,7 +20,7 @@
 
     <properties>
         <jmh.version>1.21</jmh.version>
-        <yasson.version>2.0.2-SNAPSHOT</yasson.version>
+        <yasson.version>3.0.5-SNAPSHOT</yasson.version>
     </properties>
 
 

--- a/yasson-tck/pom.xml
+++ b/yasson-tck/pom.xml
@@ -5,17 +5,38 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>2.0.4</version>
+        <relativePath/>
+    </parent>
+
     <groupId>org.eclipse</groupId>
     <artifactId>yasson-tck</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <jsonb.tck.version>3.0.0</jsonb.tck.version>
-        <yasson.version>3.0.5-SNAPSHOT</yasson.version>
-        <jakarta.json.bind.version>3.0.1</jakarta.json.bind.version>
-        <jakarta.json.version>2.1.3</jakarta.json.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+
+        <!-- API Versions -->
+        <jakarta.json.version>2.1.3</jakarta.json.version> <!-- EE10 -->
+        <jakarta.json.bind.version>3.0.1</jakarta.json.bind.version> <!-- EE10 -->
+
+        <!-- IMPL Versions -->
+        <jsonb.tck.version>3.0.0</jsonb.tck.version> <!-- EE10 -->
+        <yasson.version>3.0.5-SNAPSHOT</yasson.version> <!-- EE10 --> 
+
+        <!-- Test Versions -->
+        <junit-jupiter.version>5.14.4</junit-jupiter.version> <!-- TODO update to Junit 6 when running on Java 17+ -->  
+        <weld-se-core.version>6.0.4.Final</weld-se-core.version>
+        <arquillian-junit5-container.version>1.8.0.Final</arquillian-junit5-container.version>
+
+        <!-- Plugin Versions -->
+        <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.2.5</maven-surefire-report-plugin.version>
     </properties>
 
     <dependencies>
@@ -46,13 +67,13 @@
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
-            <version>6.0.0.Beta1</version>
+            <version>${weld-se-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.8.0.Final</version>
+            <version>${arquillian-junit5-container.version}</version>
         </dependency>
     </dependencies>
 
@@ -61,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy</id>
@@ -96,7 +117,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                     <failIfNoTests>true</failIfNoTests>
@@ -111,7 +132,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>${maven-surefire-report-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>post-unit-test</id>


### PR DESCRIPTION
Update tck runner to allow us to run against staged versions of the TCK.
Allow us to run performance tests on a schedule and upload those results to github pages. 