### PR TITLE
Convert SQL Timestamp to LocalDateTime to allow custom formatters

### DIFF
--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -14,7 +14,9 @@ package org.eclipse.yasson.internal.serializer.types;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
 /**
@@ -29,6 +31,12 @@ class SqlTimestampSerializer extends AbstractDateSerializer<Timestamp> {
 
     SqlTimestampSerializer(TypeSerializerBuilder serializerBuilder) {
         super(serializerBuilder);
+    }
+
+    @Override
+    protected TemporalAccessor toTemporalAccessor(Timestamp value) {
+        // convert SQL Timestamp into a LocalDateTime to unlock TemporalAccessor access
+        return LocalDateTime.ofInstant(value.toInstant(), UTC);
     }
 
     @Override

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
+import org.eclipse.yasson.internal.JsonbDateFormatter;
+
 /**
  * Serializer of the {@link Timestamp} type.
  */
@@ -26,16 +28,10 @@ class SqlTimestampSerializer extends AbstractDateSerializer<Timestamp> {
     /**
      * Default Yasson {@link DateTimeFormatter}.
      */
-    private static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ISO_DATE_TIME.withZone(UTC);
+    private static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE_TIME.withZone(UTC);
 
     SqlTimestampSerializer(TypeSerializerBuilder serializerBuilder) {
         super(serializerBuilder);
-    }
-
-    @Override
-    protected TemporalAccessor toTemporalAccessor(Timestamp value) {
-        // convert SQL Timestamp into a Instant to unlock TemporalAccessor access
-        return toInstant(value);
     }
 
     @Override
@@ -45,6 +41,21 @@ class SqlTimestampSerializer extends AbstractDateSerializer<Timestamp> {
 
     @Override
     protected String formatDefault(Timestamp value, Locale locale) {
-        return DEFAULT_FORMATTER.withLocale(locale).format(toInstant(value));
+        return DEFAULT_DATE_FORMATTER.withLocale(locale).format(toInstant(value));
+    }
+
+    @Override
+    protected String formatWithFormatter(Timestamp value, DateTimeFormatter formatter) {
+        return getZonedFormatter(formatter).format(toTemporalAccessor(value));
+    }
+
+    @Override
+    protected String formatStrictIJson(Timestamp value) {
+        return JsonbDateFormatter.IJSON_DATE_FORMATTER.withZone(UTC).format(toTemporalAccessor(value));
+    }
+
+    @Override
+    protected TemporalAccessor toTemporalAccessor(Timestamp value) {
+        return toInstant(value);
     }
 }

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -14,7 +14,6 @@ package org.eclipse.yasson.internal.serializer.types;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;

--- a/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
+++ b/src/main/java/org/eclipse/yasson/internal/serializer/types/SqlTimestampSerializer.java
@@ -35,8 +35,8 @@ class SqlTimestampSerializer extends AbstractDateSerializer<Timestamp> {
 
     @Override
     protected TemporalAccessor toTemporalAccessor(Timestamp value) {
-        // convert SQL Timestamp into a LocalDateTime to unlock TemporalAccessor access
-        return LocalDateTime.ofInstant(value.toInstant(), UTC);
+        // convert SQL Timestamp into a Instant to unlock TemporalAccessor access
+        return toInstant(value);
     }
 
     @Override

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
+++ b/src/test/java/org/eclipse/yasson/serializers/SerializersTest.java
@@ -16,6 +16,7 @@ import java.io.StringReader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -165,7 +166,7 @@ public class SerializersTest {
         JsonbConfig config = new JsonbConfig().withDeserializers(new CrateDeserializer());
         Jsonb jsonb = JsonbBuilder.create(config);
 
-        Box box = createPojoWithDates();
+        Box box = createPojoWithDates(getExpectedDate());
 
         String expected = "{\"boxStr\":\"Box string\",\"crate\":{\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\",\"date\":\"14.05.2015 || 11:10:01\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"date\":\"2015-05-14T11:10:01\"},\"secondBoxStr\":\"Second box string\"}";
 
@@ -253,12 +254,18 @@ public class SerializersTest {
     }
 
     @Test
+    public void testSqlTimestampSerialization() {
+        Box box = createPojoWithTimestamp(new Timestamp(getExpectedDate().getTime()));
+        assertTrue(defaultJsonb.toJson(box).contains("\"timestamp\":\"05/14/2015 @ 11:10\""));
+    }
+
+    @Test
     public void testSerializationUsingConversion() {
         JsonbConfig config = new JsonbConfig().withSerializers(new CrateSerializerWithConversion());
         Jsonb jsonb = JsonbBuilder.create(config);
 
         String json = "{\"boxStr\":\"Box string\",\"crate\":{\"crateStr\":\"REPLACED crate str\",\"crateInner\":{\"crateInnerBigDec\":10,\"crate_inner_str\":\"Single inner\",\"date\":\"14.05.2015 || 11:10:01\"},\"crateInnerList\":[{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 0\"},{\"crateInnerBigDec\":10,\"crate_inner_str\":\"List inner 1\"}],\"crateBigDec\":54321,\"date-converted\":\"2015-05-14T11:10:01Z[UTC]\"},\"secondBoxStr\":\"Second box string\"}";
-        assertEquals(json, jsonb.toJson(createPojoWithDates()));
+        assertEquals(json, jsonb.toJson(createPojoWithDates(getExpectedDate())));
     }
 
     @Test
@@ -569,8 +576,13 @@ public class SerializersTest {
         }
     }
 
-    private static Box createPojoWithDates() {
-        Date date = getExpectedDate();
+    private static Box createPojoWithTimestamp(Timestamp timestamp) {
+        Box box = createPojo();
+        box.crate.timestamp = timestamp;
+        return box;
+    }
+
+    private static Box createPojoWithDates(Date date) {
         Box box = createPojo();
         box.crate.date = date;
         box.crate.crateInner.date = date;
@@ -582,7 +594,6 @@ public class SerializersTest {
         box.boxStr = "Box string";
         box.crate = new Crate();
         box.secondBoxStr = "Second box string";
-
 
         box.crate.crateInner = createCrateInner("Single inner");
 

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
+++ b/src/test/java/org/eclipse/yasson/serializers/model/Crate.java
@@ -16,6 +16,7 @@ import jakarta.json.bind.annotation.JsonbDateFormat;
 import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.json.bind.annotation.JsonbTypeSerializer;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
@@ -35,6 +36,9 @@ public class Crate {
 
     @JsonbDateFormat("dd.MM.yyy ^ HH:mm:ss")
     public Date date;
+
+    @JsonbDateFormat("MM/dd/yyy @ HH:mm")
+    public Timestamp timestamp;
 
     public AnnotatedWithSerializerType annotatedType;
 


### PR DESCRIPTION
Fixes #577

Had to do some work on top of the original pull request to get this working and to treat the SqlTimestampSerializer the same as the DateSerializer since Timestamp is a thin wrapper around Date.  

