### PR TITLE
test: parser location used in JsonbDeserializer

### DIFF
--- a/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
+++ b/src/test/java/org/eclipse/yasson/adapters/JsonbTypeAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.yasson.adapters.model.*;
 import jakarta.json.bind.JsonbException;
 import jakarta.json.bind.adapter.JsonbAdapter;
 import jakarta.json.bind.annotation.JsonbTypeAdapter;
+import jakarta.json.bind.annotation.JsonbTypeDeserializer;
 
 /**
  * @author Roman Grigoriadi
@@ -119,5 +120,27 @@ public class JsonbTypeAdapterTest {
         BoxWithDeserializer result = defaultJsonb.fromJson("{\"boxInteger\":101,\"boxStr\":\"STR\"}", BoxWithDeserializer.class);
         assertEquals("STR", result.getBoxStrField());
         assertEquals(Integer.valueOf(101), result.getBoxIntegerField());
+    }
+
+    public static class BoxWithPrimitiveBooleanDeserializer {
+        @JsonbTypeDeserializer(CustomBooleanDeserializer.class)
+        public boolean bool;
+    }
+
+    @Test
+    public void testPrimitiveDeserialzier() {
+        String successfulJson = "{\"bool\":true}";
+        BoxWithPrimitiveBooleanDeserializer result = defaultJsonb.fromJson(successfulJson, BoxWithPrimitiveBooleanDeserializer.class);
+        assertTrue(result.bool);
+
+        String failingJson = "{\"bool\":\"true\"}";
+        try {
+            defaultJsonb.fromJson(failingJson, BoxWithPrimitiveBooleanDeserializer.class);
+            fail();
+        } catch (JsonbException e) {
+            assertTrue(e.getCause() instanceof IllegalStateException);
+            assertEquals("Unexpected value: VALUE_STRING", e.getCause().getMessage());
+        }
+
     }
 }

--- a/src/test/java/org/eclipse/yasson/adapters/model/CustomBooleanDeserializer.java
+++ b/src/test/java/org/eclipse/yasson/adapters/model/CustomBooleanDeserializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Eclipse and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.yasson.adapters.model;
+
+import java.lang.reflect.Type;
+
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+public class CustomBooleanDeserializer implements JsonbDeserializer<Boolean> {
+
+    @Override
+    public Boolean deserialize(JsonParser jsonParser, DeserializationContext ctx, Type rtType) {
+
+        // The provided parser is already positioned on the value to be deserialized, 
+        // so we can just check the event type and return the corresponding boolean value.
+        // Should Yasson have instead provided a parser that is positioned at the start of the key-value pair?
+        // The specification nor API Javadoc seem to specifiy where the parser should be positioned.
+        JsonParser.Event event = jsonParser.currentEvent();
+
+        switch(event) {
+            case VALUE_TRUE:
+                return true;
+            case VALUE_FALSE:
+                return false;
+            default:
+                throw new IllegalStateException("Unexpected value: " + event);
+        }        
+    }
+    
+}


### PR DESCRIPTION
I was discussing this scenario with a user, where they expected the parser that is passed into the `deserialize` method of the `JsonbDeserializer` API to be at the beginning of the object either `START_OBJECT` or `KEY_NAME`.  However, the current behavior in Yasson is to provide a parser that is already at the `VALUE_*` position. 

I searched the spec and javadoc and there is no clarity on this so it is something a user would have to know depending on the implementation they are using. 

In their case, they wanted to be at the `START_OBJECT` location so that they could create a meaningful error message when deserialization needs to fail based on their application needs.  However, that does not look possible today. 